### PR TITLE
Support multiple database driver

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,4 +1,4 @@
-import _root_.servlet.{BasicAuthenticationFilter, TransactionFilter}
+import _root_.servlet.{BasicAuthenticationFilter, Database, TransactionFilter}
 import app._
 import jp.sf.amateras.scalatra.forms.ValidationJavaScriptProvider
 import org.scalatra._
@@ -7,27 +7,30 @@ import java.util.EnumSet
 
 class ScalatraBootstrap extends LifeCycle {
   override def init(context: ServletContext) {
+    // Retrieve Slick driver
+    val driver = Database.driver(context)
+
     // Register TransactionFilter and BasicAuthenticationFilter at first
     context.addFilter("transactionFilter", new TransactionFilter)
     context.getFilterRegistration("transactionFilter").addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/*")
-    context.addFilter("basicAuthenticationFilter", new BasicAuthenticationFilter)
+    context.addFilter("basicAuthenticationFilter", new BasicAuthenticationFilter(driver))
     context.getFilterRegistration("basicAuthenticationFilter").addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/git/*")
 
     // Register controllers
-    context.mount(new IndexController, "/")
-    context.mount(new SearchController, "/")
+    context.mount(new IndexController(driver), "/")
+    context.mount(new SearchController(driver), "/")
     context.mount(new FileUploadController, "/upload")
-    context.mount(new DashboardController, "/*")
-    context.mount(new UserManagementController, "/*")
-    context.mount(new SystemSettingsController, "/*")
-    context.mount(new AccountController, "/*")
-    context.mount(new RepositoryViewerController, "/*")
-    context.mount(new WikiController, "/*")
-    context.mount(new LabelsController, "/*")
-    context.mount(new MilestonesController, "/*")
-    context.mount(new IssuesController, "/*")
-    context.mount(new PullRequestsController, "/*")
-    context.mount(new RepositorySettingsController, "/*")
+    context.mount(new DashboardController(driver), "/*")
+    context.mount(new UserManagementController(driver), "/*")
+    context.mount(new SystemSettingsController(driver), "/*")
+    context.mount(new AccountController(driver), "/*")
+    context.mount(new RepositoryViewerController(driver), "/*")
+    context.mount(new WikiController(driver), "/*")
+    context.mount(new LabelsController(driver), "/*")
+    context.mount(new MilestonesController(driver), "/*")
+    context.mount(new IssuesController(driver), "/*")
+    context.mount(new PullRequestsController(driver), "/*")
+    context.mount(new RepositorySettingsController(driver), "/*")
     context.mount(new ValidationJavaScriptProvider, "/assets/common/js/*")
 
     // Create GITBUCKET_HOME directory if it does not exist

--- a/src/main/scala/app/AccountController.scala
+++ b/src/main/scala/app/AccountController.scala
@@ -1,5 +1,6 @@
 package app
 
+import model.Profile
 import service._
 import util._
 import util.StringUtil._
@@ -12,14 +13,15 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.{FileMode, Constants}
 import org.eclipse.jgit.dircache.DirCache
 import model.GroupMember
+import scala.slick.driver.ExtendedProfile
 
-class AccountController extends AccountControllerBase
+class AccountController(override val profile: ExtendedProfile) extends AccountControllerBase
   with AccountService with RepositoryService with ActivityService with WikiService with LabelsService
-  with OneselfAuthenticator with UsersAuthenticator with GroupManagerAuthenticator with ReadableUsersAuthenticator
+  with OneselfAuthenticator with UsersAuthenticator with GroupManagerAuthenticator with ReadableUsersAuthenticator with Profile
 
 trait AccountControllerBase extends AccountManagementControllerBase {
   self: AccountService with RepositoryService with ActivityService with WikiService with LabelsService
-    with OneselfAuthenticator with UsersAuthenticator with GroupManagerAuthenticator with ReadableUsersAuthenticator =>
+    with OneselfAuthenticator with UsersAuthenticator with GroupManagerAuthenticator with ReadableUsersAuthenticator with Profile =>
 
   case class AccountNewForm(userName: String, password: String, fullName: String, mailAddress: String,
                             url: Option[String], fileId: Option[String])

--- a/src/main/scala/app/DashboardController.scala
+++ b/src/main/scala/app/DashboardController.scala
@@ -1,12 +1,14 @@
 package app
 
+import model.Profile
 import service._
 import util.{UsersAuthenticator, Keys}
 import util.Implicits._
+import scala.slick.driver.ExtendedProfile
 
-class DashboardController extends DashboardControllerBase
+class DashboardController(override val profile: ExtendedProfile) extends DashboardControllerBase
   with IssuesService with PullRequestService with RepositoryService with AccountService
-  with UsersAuthenticator
+  with UsersAuthenticator with Profile
 
 trait DashboardControllerBase extends ControllerBase {
   self: IssuesService with PullRequestService with RepositoryService with UsersAuthenticator =>

--- a/src/main/scala/app/IndexController.scala
+++ b/src/main/scala/app/IndexController.scala
@@ -1,14 +1,16 @@
 package app
 
 import util._
+import model.Profile
 import service._
 import jp.sf.amateras.scalatra.forms._
+import scala.slick.driver.ExtendedProfile
 
-class IndexController extends IndexControllerBase 
-  with RepositoryService with ActivityService with AccountService with UsersAuthenticator
+class IndexController(override val profile: ExtendedProfile) extends IndexControllerBase
+  with RepositoryService with ActivityService with AccountService with UsersAuthenticator with Profile
 
 trait IndexControllerBase extends ControllerBase {
-  self: RepositoryService with ActivityService with AccountService with UsersAuthenticator =>
+  self: RepositoryService with ActivityService with AccountService with UsersAuthenticator with Profile =>
 
   case class SignInForm(userName: String, password: String)
 

--- a/src/main/scala/app/IssuesController.scala
+++ b/src/main/scala/app/IssuesController.scala
@@ -8,15 +8,16 @@ import util._
 import util.Implicits._
 import util.ControlUtil._
 import org.scalatra.Ok
-import model.Issue
+import model.{Issue, Profile}
+import scala.slick.driver.ExtendedProfile
 
-class IssuesController extends IssuesControllerBase
+class IssuesController(override val profile: ExtendedProfile) extends IssuesControllerBase
   with IssuesService with RepositoryService with AccountService with LabelsService with MilestonesService with ActivityService
-  with ReadableUsersAuthenticator with ReferrerAuthenticator with CollaboratorsAuthenticator
+  with ReadableUsersAuthenticator with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile
 
 trait IssuesControllerBase extends ControllerBase {
   self: IssuesService with RepositoryService with AccountService with LabelsService with MilestonesService with ActivityService
-    with ReadableUsersAuthenticator with ReferrerAuthenticator with CollaboratorsAuthenticator =>
+    with ReadableUsersAuthenticator with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile =>
 
   case class IssueCreateForm(title: String, content: Option[String],
     assignedUserName: Option[String], milestoneId: Option[Int], labelNames: Option[String])
@@ -117,7 +118,7 @@ trait IssuesControllerBase extends ControllerBase {
       }
 
       // notifications
-      Notifier().toNotify(repository, issueId, form.content.getOrElse("")){
+      Notifier(profile).toNotify(repository, issueId, form.content.getOrElse("")){
         Notifier.msgIssue(s"${baseUrl}/${owner}/${name}/issues/${issueId}")
       }
 
@@ -338,7 +339,7 @@ trait IssuesControllerBase extends ControllerBase {
         }
 
         // notifications
-        Notifier() match {
+        Notifier(profile) match {
           case f =>
             content foreach {
               f.toNotify(repository, issueId, _){

--- a/src/main/scala/app/LabelsController.scala
+++ b/src/main/scala/app/LabelsController.scala
@@ -1,15 +1,17 @@
 package app
 
 import jp.sf.amateras.scalatra.forms._
+import model.Profile
 import service._
 import util.CollaboratorsAuthenticator
 import org.scalatra.i18n.Messages
+import scala.slick.driver.ExtendedProfile
 
-class LabelsController extends LabelsControllerBase
-  with LabelsService with RepositoryService with AccountService with CollaboratorsAuthenticator
+class LabelsController(override val profile: ExtendedProfile) extends LabelsControllerBase
+  with LabelsService with RepositoryService with AccountService with CollaboratorsAuthenticator with Profile
 
 trait LabelsControllerBase extends ControllerBase {
-  self: LabelsService with RepositoryService with CollaboratorsAuthenticator =>
+  self: LabelsService with RepositoryService with CollaboratorsAuthenticator with Profile =>
 
   case class LabelForm(labelName: String, color: String)
 

--- a/src/main/scala/app/MilestonesController.scala
+++ b/src/main/scala/app/MilestonesController.scala
@@ -2,17 +2,19 @@ package app
 
 import jp.sf.amateras.scalatra.forms._
 
+import model.Profile
 import service._
 import util.{CollaboratorsAuthenticator, ReferrerAuthenticator}
 import util.Implicits._
+import scala.slick.driver.ExtendedProfile
 
-class MilestonesController extends MilestonesControllerBase
+class MilestonesController(override val profile: ExtendedProfile) extends MilestonesControllerBase
   with MilestonesService with RepositoryService with AccountService
-  with ReferrerAuthenticator with CollaboratorsAuthenticator
+  with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile
 
 trait MilestonesControllerBase extends ControllerBase {
   self: MilestonesService with RepositoryService
-    with ReferrerAuthenticator with CollaboratorsAuthenticator  =>
+    with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile =>
 
   case class MilestoneForm(title: String, description: Option[String], dueDate: Option[java.util.Date])
 

--- a/src/main/scala/app/PullRequestsController.scala
+++ b/src/main/scala/app/PullRequestsController.scala
@@ -4,6 +4,7 @@ import util.{LockUtil, CollaboratorsAuthenticator, JGitUtil, ReferrerAuthenticat
 import util.Directory._
 import util.Implicits._
 import util.ControlUtil._
+import model.Profile
 import service._
 import org.eclipse.jgit.api.Git
 import jp.sf.amateras.scalatra.forms._
@@ -19,14 +20,15 @@ import org.slf4j.LoggerFactory
 import org.eclipse.jgit.merge.MergeStrategy
 import org.eclipse.jgit.errors.NoMergeBaseException
 import service.WebHookService.WebHookPayload
+import scala.slick.driver.ExtendedProfile
 
-class PullRequestsController extends PullRequestsControllerBase
+class PullRequestsController(override val profile: ExtendedProfile) extends PullRequestsControllerBase
   with RepositoryService with AccountService with IssuesService with PullRequestService with MilestonesService with LabelsService
-  with ActivityService with WebHookService with ReferrerAuthenticator with CollaboratorsAuthenticator
+  with ActivityService with WebHookService with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile
 
 trait PullRequestsControllerBase extends ControllerBase {
   self: RepositoryService with AccountService with IssuesService with MilestonesService with LabelsService
-    with ActivityService with PullRequestService with WebHookService with ReferrerAuthenticator with CollaboratorsAuthenticator =>
+    with ActivityService with PullRequestService with WebHookService with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile =>
 
   private val logger = LoggerFactory.getLogger(classOf[PullRequestsControllerBase])
 
@@ -206,7 +208,7 @@ trait PullRequestsControllerBase extends ControllerBase {
             }
 
             // notifications
-            Notifier().toNotify(repository, issueId, "merge"){
+            Notifier(profile).toNotify(repository, issueId, "merge"){
               Notifier.msgStatus(s"${baseUrl}/${owner}/${name}/pull/${issueId}")
             }
 
@@ -361,7 +363,7 @@ trait PullRequestsControllerBase extends ControllerBase {
     recordPullRequestActivity(repository.owner, repository.name, loginUserName, issueId, form.title)
 
     // notifications
-    Notifier().toNotify(repository, issueId, form.content.getOrElse("")){
+    Notifier(profile).toNotify(repository, issueId, form.content.getOrElse("")){
       Notifier.msgPullRequest(s"${baseUrl}/${repository.owner}/${repository.name}/pull/${issueId}")
     }
 

--- a/src/main/scala/app/RepositorySettingsController.scala
+++ b/src/main/scala/app/RepositorySettingsController.scala
@@ -1,5 +1,6 @@
 package app
 
+import model.Profile
 import service._
 import util.Directory._
 import util.{UsersAuthenticator, OwnerAuthenticator}
@@ -10,14 +11,15 @@ import service.WebHookService.WebHookPayload
 import util.JGitUtil.CommitInfo
 import util.ControlUtil._
 import org.eclipse.jgit.api.Git
+import scala.slick.driver.ExtendedProfile
 
-class RepositorySettingsController extends RepositorySettingsControllerBase
+class RepositorySettingsController(override val profile: ExtendedProfile) extends RepositorySettingsControllerBase
   with RepositoryService with AccountService with WebHookService
-  with OwnerAuthenticator with UsersAuthenticator
+  with OwnerAuthenticator with UsersAuthenticator with Profile
 
 trait RepositorySettingsControllerBase extends ControllerBase {
   self: RepositoryService with AccountService with WebHookService
-    with OwnerAuthenticator with UsersAuthenticator =>
+    with OwnerAuthenticator with UsersAuthenticator with Profile =>
 
   // for repository options
   case class OptionsForm(repositoryName: String, description: Option[String], defaultBranch: String, isPrivate: Boolean)

--- a/src/main/scala/app/RepositoryViewerController.scala
+++ b/src/main/scala/app/RepositoryViewerController.scala
@@ -4,6 +4,7 @@ import util.Directory._
 import util.Implicits._
 import util.ControlUtil._
 import _root_.util._
+import model.Profile
 import service._
 import org.scalatra._
 import java.io.File
@@ -13,15 +14,16 @@ import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.treewalk._
 import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.Some
+import scala.slick.driver.ExtendedProfile
 
-class RepositoryViewerController extends RepositoryViewerControllerBase 
-  with RepositoryService with AccountService with ActivityService with ReferrerAuthenticator with CollaboratorsAuthenticator
+class RepositoryViewerController(override val profile: ExtendedProfile) extends RepositoryViewerControllerBase
+  with RepositoryService with AccountService with ActivityService with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile
 
 /**
  * The repository viewer.
  */
 trait RepositoryViewerControllerBase extends ControllerBase { 
-  self: RepositoryService with AccountService with ActivityService with ReferrerAuthenticator with CollaboratorsAuthenticator =>
+  self: RepositoryService with AccountService with ActivityService with ReferrerAuthenticator with CollaboratorsAuthenticator with Profile =>
 
   /**
    * Returns converted HTML from Markdown for preview.

--- a/src/main/scala/app/SearchController.scala
+++ b/src/main/scala/app/SearchController.scala
@@ -2,14 +2,16 @@ package app
 
 import util._
 import ControlUtil._
+import model.Profile
 import service._
 import jp.sf.amateras.scalatra.forms._
+import scala.slick.driver.ExtendedProfile
 
-class SearchController extends SearchControllerBase
-  with RepositoryService with AccountService with ActivityService with RepositorySearchService with IssuesService with ReferrerAuthenticator
+class SearchController(override val profile: ExtendedProfile) extends SearchControllerBase
+  with RepositoryService with AccountService with ActivityService with RepositorySearchService with IssuesService with ReferrerAuthenticator with Profile
 
 trait SearchControllerBase extends ControllerBase { self: RepositoryService
-  with ActivityService with RepositorySearchService with ReferrerAuthenticator =>
+  with ActivityService with RepositorySearchService with ReferrerAuthenticator with Profile =>
 
   val searchForm = mapping(
     "query"      -> trim(text(required)),

--- a/src/main/scala/app/SystemSettingsController.scala
+++ b/src/main/scala/app/SystemSettingsController.scala
@@ -1,15 +1,17 @@
 package app
 
+import model.Profile
 import service.{AccountService, SystemSettingsService}
 import SystemSettingsService._
 import util.AdminAuthenticator
 import jp.sf.amateras.scalatra.forms._
+import scala.slick.driver.ExtendedProfile
 
-class SystemSettingsController extends SystemSettingsControllerBase
-  with SystemSettingsService with AccountService with AdminAuthenticator
+class SystemSettingsController(override val profile: ExtendedProfile) extends SystemSettingsControllerBase
+  with SystemSettingsService with AccountService with AdminAuthenticator with Profile
 
 trait SystemSettingsControllerBase extends ControllerBase {
-  self: SystemSettingsService with AccountService with AdminAuthenticator =>
+  self: SystemSettingsService with AccountService with AdminAuthenticator with Profile =>
 
   private val form = mapping(
     "baseUrl"                  -> trim(label("Base URL", optional(text()))),

--- a/src/main/scala/app/UserManagementController.scala
+++ b/src/main/scala/app/UserManagementController.scala
@@ -1,5 +1,6 @@
 package app
 
+import model.Profile
 import service._
 import util.AdminAuthenticator
 import util.StringUtil._
@@ -7,13 +8,14 @@ import util.ControlUtil._
 import jp.sf.amateras.scalatra.forms._
 import org.scalatra.i18n.Messages
 import org.apache.commons.io.FileUtils
+import scala.slick.driver.ExtendedProfile
 import util.Directory._
 
-class UserManagementController extends UserManagementControllerBase
-  with AccountService with RepositoryService with AdminAuthenticator
+class UserManagementController(override val profile: ExtendedProfile) extends UserManagementControllerBase
+  with AccountService with RepositoryService with AdminAuthenticator with Profile
 
 trait UserManagementControllerBase extends AccountManagementControllerBase {
-  self: AccountService with RepositoryService with AdminAuthenticator =>
+  self: AccountService with RepositoryService with AdminAuthenticator with Profile =>
   
   case class NewUserForm(userName: String, password: String, fullName: String,
                          mailAddress: String, isAdmin: Boolean,

--- a/src/main/scala/app/WikiController.scala
+++ b/src/main/scala/app/WikiController.scala
@@ -1,5 +1,6 @@
 package app
 
+import model.Profile
 import service._
 import util._
 import util.Directory._
@@ -8,13 +9,14 @@ import jp.sf.amateras.scalatra.forms._
 import org.eclipse.jgit.api.Git
 import org.scalatra.i18n.Messages
 import scala.Some
+import scala.slick.driver.ExtendedProfile
 import java.util.ResourceBundle
 
-class WikiController extends WikiControllerBase 
-  with WikiService with RepositoryService with AccountService with ActivityService with CollaboratorsAuthenticator with ReferrerAuthenticator
+class WikiController(override val profile: ExtendedProfile) extends WikiControllerBase
+  with WikiService with RepositoryService with AccountService with ActivityService with CollaboratorsAuthenticator with ReferrerAuthenticator with Profile
 
 trait WikiControllerBase extends ControllerBase {
-  self: WikiService with RepositoryService with ActivityService with CollaboratorsAuthenticator with ReferrerAuthenticator =>
+  self: WikiService with RepositoryService with ActivityService with CollaboratorsAuthenticator with ReferrerAuthenticator with Profile =>
 
   case class WikiPageEditForm(pageName: String, content: String, message: Option[String], currentPageName: String, id: String)
   

--- a/src/main/scala/model/Account.scala
+++ b/src/main/scala/model/Account.scala
@@ -1,21 +1,23 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait AccountComponent { self: Profile =>
+  import profile.simple._
 
-object Accounts extends Table[Account]("ACCOUNT") {
-  def userName = column[String]("USER_NAME", O PrimaryKey)
-  def fullName = column[String]("FULL_NAME")
-  def mailAddress = column[String]("MAIL_ADDRESS")
-  def password = column[String]("PASSWORD")
-  def isAdmin = column[Boolean]("ADMINISTRATOR")
-  def url = column[String]("URL")
-  def registeredDate = column[java.util.Date]("REGISTERED_DATE")
-  def updatedDate = column[java.util.Date]("UPDATED_DATE")
-  def lastLoginDate = column[java.util.Date]("LAST_LOGIN_DATE")
-  def image = column[String]("IMAGE")
-  def groupAccount = column[Boolean]("GROUP_ACCOUNT")
-  def removed = column[Boolean]("REMOVED")
-  def * = userName ~ fullName ~ mailAddress ~ password ~ isAdmin ~ url.? ~ registeredDate ~ updatedDate ~ lastLoginDate.? ~ image.? ~ groupAccount ~ removed <> (Account, Account.unapply _)
+  object Accounts extends Table[Account]("ACCOUNT") {
+    def userName = column[String]("USER_NAME", O PrimaryKey)
+    def fullName = column[String]("FULL_NAME")
+    def mailAddress = column[String]("MAIL_ADDRESS")
+    def password = column[String]("PASSWORD")
+    def isAdmin = column[Boolean]("ADMINISTRATOR")
+    def url = column[String]("URL")
+    def registeredDate = column[java.util.Date]("REGISTERED_DATE")
+    def updatedDate = column[java.util.Date]("UPDATED_DATE")
+    def lastLoginDate = column[java.util.Date]("LAST_LOGIN_DATE")
+    def image = column[String]("IMAGE")
+    def groupAccount = column[Boolean]("GROUP_ACCOUNT")
+    def removed = column[Boolean]("REMOVED")
+    def * = userName ~ fullName ~ mailAddress ~ password ~ isAdmin ~ url.? ~ registeredDate ~ updatedDate ~ lastLoginDate.? ~ image.? ~ groupAccount ~ removed <> (Account, Account.unapply _)
+  }
 }
 
 case class Account(

--- a/src/main/scala/model/Activity.scala
+++ b/src/main/scala/model/Activity.scala
@@ -1,22 +1,24 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait ActivityComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object Activities extends Table[Activity]("ACTIVITY") with BasicTemplate {
-  def activityId = column[Int]("ACTIVITY_ID", O AutoInc)
-  def activityUserName = column[String]("ACTIVITY_USER_NAME")
-  def activityType = column[String]("ACTIVITY_TYPE")
-  def message = column[String]("MESSAGE")
-  def additionalInfo = column[String]("ADDITIONAL_INFO")
-  def activityDate = column[java.util.Date]("ACTIVITY_DATE")
-  def * = activityId ~ userName ~ repositoryName ~ activityUserName ~ activityType ~ message ~ additionalInfo.? ~ activityDate <> (Activity, Activity.unapply _)
-  def autoInc = userName ~ repositoryName ~ activityUserName ~ activityType ~ message ~ additionalInfo.? ~ activityDate returning activityId
-}
+  object Activities extends Table[Activity]("ACTIVITY") with BasicTemplate {
+    def activityId = column[Int]("ACTIVITY_ID", O AutoInc)
+    def activityUserName = column[String]("ACTIVITY_USER_NAME")
+    def activityType = column[String]("ACTIVITY_TYPE")
+    def message = column[String]("MESSAGE")
+    def additionalInfo = column[String]("ADDITIONAL_INFO")
+    def activityDate = column[java.util.Date]("ACTIVITY_DATE")
+    def * = activityId ~ userName ~ repositoryName ~ activityUserName ~ activityType ~ message ~ additionalInfo.? ~ activityDate <> (Activity, Activity.unapply _)
+    def autoInc = userName ~ repositoryName ~ activityUserName ~ activityType ~ message ~ additionalInfo.? ~ activityDate returning activityId
+  }
 
-object CommitLog extends Table[(String, String, String)]("COMMIT_LOG") with BasicTemplate {
-  def commitId = column[String]("COMMIT_ID")
-  def * = userName ~ repositoryName ~ commitId
-  def byPrimaryKey(userName: String, repositoryName: String, commitId: String) = byRepository(userName, repositoryName) && (this.commitId is commitId.bind)
+  object CommitLog extends Table[(String, String, String)]("COMMIT_LOG") with BasicTemplate {
+    def commitId = column[String]("COMMIT_ID")
+    def * = userName ~ repositoryName ~ commitId
+    def byPrimaryKey(userName: String, repositoryName: String, commitId: String) = byRepository(userName, repositoryName) && (this.commitId is commitId.bind)
+  }
 }
 
 case class Activity(

--- a/src/main/scala/model/BasicTemplate.scala
+++ b/src/main/scala/model/BasicTemplate.scala
@@ -1,44 +1,58 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+protected[model] trait BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-protected[model] trait BasicTemplate { self: Table[_] =>
-  def userName = column[String]("USER_NAME")
-  def repositoryName = column[String]("REPOSITORY_NAME")
+  trait BasicTemplate { table: Table[_] =>
+    def userName = column[String]("USER_NAME")
+    def repositoryName = column[String]("REPOSITORY_NAME")
 
-  def byRepository(owner: String, repository: String) =
-    (userName is owner.bind) && (repositoryName is repository.bind)
+    def byRepository(owner: String, repository: String) =
+      (userName is owner.bind) && (repositoryName is repository.bind)
 
-  def byRepository(userName: Column[String], repositoryName: Column[String]) =
-    (this.userName is userName) && (this.repositoryName is repositoryName)
+    def byRepository(userName: Column[String], repositoryName: Column[String]) =
+      (this.userName is userName) && (this.repositoryName is repositoryName)
+  }
 }
 
-protected[model] trait IssueTemplate extends BasicTemplate { self: Table[_] =>
-  def issueId = column[Int]("ISSUE_ID")
+protected[model] trait IssueTemplateComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-  def byIssue(owner: String, repository: String, issueId: Int) =
-    byRepository(owner, repository) && (this.issueId is issueId.bind)
+  trait IssueTemplate extends BasicTemplate { table: Table[_] =>
+    def issueId = column[Int]("ISSUE_ID")
 
-  def byIssue(userName: Column[String], repositoryName: Column[String], issueId: Column[Int]) =
-    byRepository(userName, repositoryName) && (this.issueId is issueId)
+    def byIssue(owner: String, repository: String, issueId: Int) =
+      byRepository(owner, repository) && (this.issueId is issueId.bind)
+
+    def byIssue(userName: Column[String], repositoryName: Column[String], issueId: Column[Int]) =
+      byRepository(userName, repositoryName) && (this.issueId is issueId)
+  }
 }
 
-protected[model] trait LabelTemplate extends BasicTemplate { self: Table[_] =>
-  def labelId = column[Int]("LABEL_ID")
+protected[model] trait LabelTemplateComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-  def byLabel(owner: String, repository: String, labelId: Int) =
-    byRepository(owner, repository) && (this.labelId is labelId.bind)
+  trait LabelTemplate extends BasicTemplate { table: Table[_] =>
+    def labelId = column[Int]("LABEL_ID")
 
-  def byLabel(userName: Column[String], repositoryName: Column[String], labelId: Column[Int]) =
-    byRepository(userName, repositoryName) && (this.labelId is labelId)
+    def byLabel(owner: String, repository: String, labelId: Int) =
+      byRepository(owner, repository) && (this.labelId is labelId.bind)
+
+    def byLabel(userName: Column[String], repositoryName: Column[String], labelId: Column[Int]) =
+      byRepository(userName, repositoryName) && (this.labelId is labelId)
+  }
 }
 
-protected[model] trait MilestoneTemplate extends BasicTemplate { self: Table[_] =>
-  def milestoneId = column[Int]("MILESTONE_ID")
+protected[model] trait MilestoneTemplateComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-  def byMilestone(owner: String, repository: String, milestoneId: Int) =
-    byRepository(owner, repository) && (this.milestoneId is milestoneId.bind)
+  protected[model] trait MilestoneTemplate extends BasicTemplate { table: Table[_] =>
+    def milestoneId = column[Int]("MILESTONE_ID")
 
-  def byMilestone(userName: Column[String], repositoryName: Column[String], milestoneId: Column[Int]) =
-    byRepository(userName, repositoryName) && (this.milestoneId is milestoneId)
+    def byMilestone(owner: String, repository: String, milestoneId: Int) =
+      byRepository(owner, repository) && (this.milestoneId is milestoneId.bind)
+
+    def byMilestone(userName: Column[String], repositoryName: Column[String], milestoneId: Column[Int]) =
+      byRepository(userName, repositoryName) && (this.milestoneId is milestoneId)
+  }
 }

--- a/src/main/scala/model/Collaborator.scala
+++ b/src/main/scala/model/Collaborator.scala
@@ -1,13 +1,15 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait CollaboratorComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object Collaborators extends Table[Collaborator]("COLLABORATOR") with BasicTemplate {
-  def collaboratorName = column[String]("COLLABORATOR_NAME")
-  def * = userName ~ repositoryName ~ collaboratorName <> (Collaborator, Collaborator.unapply _)
+  object Collaborators extends Table[Collaborator]("COLLABORATOR") with BasicTemplate {
+    def collaboratorName = column[String]("COLLABORATOR_NAME")
+    def * = userName ~ repositoryName ~ collaboratorName <> (Collaborator, Collaborator.unapply _)
 
-  def byPrimaryKey(owner: String, repository: String, collaborator: String) =
-    byRepository(owner, repository) && (collaboratorName is collaborator.bind)
+    def byPrimaryKey(owner: String, repository: String, collaborator: String) =
+      byRepository(owner, repository) && (collaboratorName is collaborator.bind)
+  }
 }
 
 case class Collaborator(

--- a/src/main/scala/model/GroupMembers.scala
+++ b/src/main/scala/model/GroupMembers.scala
@@ -1,12 +1,14 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait GroupMemberComponent { self: Profile =>
+  import profile.simple._
 
-object GroupMembers extends Table[GroupMember]("GROUP_MEMBER") {
-  def groupName = column[String]("GROUP_NAME", O PrimaryKey)
-  def userName = column[String]("USER_NAME", O PrimaryKey)
-  def isManager = column[Boolean]("MANAGER")
-  def * = groupName ~ userName ~ isManager <> (GroupMember, GroupMember.unapply _)
+  object GroupMembers extends Table[GroupMember]("GROUP_MEMBER") {
+    def groupName = column[String]("GROUP_NAME", O PrimaryKey)
+    def userName = column[String]("USER_NAME", O PrimaryKey)
+    def isManager = column[Boolean]("MANAGER")
+    def * = groupName ~ userName ~ isManager <> (GroupMember, GroupMember.unapply _)
+  }
 }
 
 case class GroupMember(

--- a/src/main/scala/model/Issue.scala
+++ b/src/main/scala/model/Issue.scala
@@ -1,29 +1,31 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait IssueComponent extends IssueTemplateComponent with MilestoneTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object IssueId extends Table[(String, String, Int)]("ISSUE_ID") with IssueTemplate {
-  def * = userName ~ repositoryName ~ issueId
-  def byPrimaryKey(owner: String, repository: String) = byRepository(owner, repository)
-}
+  object IssueId extends Table[(String, String, Int)]("ISSUE_ID") with IssueTemplate {
+    def * = userName ~ repositoryName ~ issueId
+    def byPrimaryKey(owner: String, repository: String) = byRepository(owner, repository)
+  }
 
-object IssueOutline extends Table[(String, String, Int, Int)]("ISSUE_OUTLINE_VIEW") with IssueTemplate {
-  def commentCount = column[Int]("COMMENT_COUNT")
-  def * = userName ~ repositoryName ~ issueId ~ commentCount
-}
+  object IssueOutline extends Table[(String, String, Int, Int)]("ISSUE_OUTLINE_VIEW") with IssueTemplate {
+    def commentCount = column[Int]("COMMENT_COUNT")
+    def * = userName ~ repositoryName ~ issueId ~ commentCount
+  }
 
-object Issues extends Table[Issue]("ISSUE") with IssueTemplate with MilestoneTemplate {
-  def openedUserName = column[String]("OPENED_USER_NAME")
-  def assignedUserName = column[String]("ASSIGNED_USER_NAME")
-  def title = column[String]("TITLE")
-  def content = column[String]("CONTENT")
-  def closed = column[Boolean]("CLOSED")
-  def registeredDate = column[java.util.Date]("REGISTERED_DATE")
-  def updatedDate = column[java.util.Date]("UPDATED_DATE")
-  def pullRequest = column[Boolean]("PULL_REQUEST")
-  def * = userName ~ repositoryName ~ issueId ~ openedUserName ~ milestoneId.? ~ assignedUserName.? ~ title ~ content.? ~ closed ~ registeredDate ~ updatedDate ~ pullRequest <> (Issue, Issue.unapply _)
+  object Issues extends Table[Issue]("ISSUE") with IssueTemplate with MilestoneTemplate {
+    def openedUserName = column[String]("OPENED_USER_NAME")
+    def assignedUserName = column[String]("ASSIGNED_USER_NAME")
+    def title = column[String]("TITLE")
+    def content = column[String]("CONTENT")
+    def closed = column[Boolean]("CLOSED")
+    def registeredDate = column[java.util.Date]("REGISTERED_DATE")
+    def updatedDate = column[java.util.Date]("UPDATED_DATE")
+    def pullRequest = column[Boolean]("PULL_REQUEST")
+    def * = userName ~ repositoryName ~ issueId ~ openedUserName ~ milestoneId.? ~ assignedUserName.? ~ title ~ content.? ~ closed ~ registeredDate ~ updatedDate ~ pullRequest <> (Issue, Issue.unapply _)
 
-  def byPrimaryKey(owner: String, repository: String, issueId: Int) = byIssue(owner, repository, issueId)
+    def byPrimaryKey(owner: String, repository: String, issueId: Int) = byIssue(owner, repository, issueId)
+  }
 }
 
 case class Issue(

--- a/src/main/scala/model/IssueComment.scala
+++ b/src/main/scala/model/IssueComment.scala
@@ -1,18 +1,20 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait IssueCommentComponent extends IssueTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object IssueComments extends Table[IssueComment]("ISSUE_COMMENT") with IssueTemplate {
-  def commentId = column[Int]("COMMENT_ID", O AutoInc)
-  def action = column[String]("ACTION")
-  def commentedUserName = column[String]("COMMENTED_USER_NAME")
-  def content = column[String]("CONTENT")
-  def registeredDate = column[java.util.Date]("REGISTERED_DATE")
-  def updatedDate = column[java.util.Date]("UPDATED_DATE")
-  def * = userName ~ repositoryName ~ issueId ~ commentId ~ action ~ commentedUserName ~ content ~ registeredDate ~ updatedDate <> (IssueComment, IssueComment.unapply _)
+  object IssueComments extends Table[IssueComment]("ISSUE_COMMENT") with IssueTemplate {
+    def commentId = column[Int]("COMMENT_ID", O AutoInc)
+    def action = column[String]("ACTION")
+    def commentedUserName = column[String]("COMMENTED_USER_NAME")
+    def content = column[String]("CONTENT")
+    def registeredDate = column[java.util.Date]("REGISTERED_DATE")
+    def updatedDate = column[java.util.Date]("UPDATED_DATE")
+    def * = userName ~ repositoryName ~ issueId ~ commentId ~ action ~ commentedUserName ~ content ~ registeredDate ~ updatedDate <> (IssueComment, IssueComment.unapply _)
 
-  def autoInc = userName ~ repositoryName ~ issueId ~ action ~ commentedUserName ~ content ~ registeredDate ~ updatedDate returning commentId
-  def byPrimaryKey(commentId: Int) = this.commentId is commentId.bind
+    def autoInc = userName ~ repositoryName ~ issueId ~ action ~ commentedUserName ~ content ~ registeredDate ~ updatedDate returning commentId
+    def byPrimaryKey(commentId: Int) = this.commentId is commentId.bind
+  }
 }
 
 case class IssueComment(

--- a/src/main/scala/model/IssueLabels.scala
+++ b/src/main/scala/model/IssueLabels.scala
@@ -1,11 +1,13 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait IssueLabelComponent extends IssueTemplateComponent with LabelTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object IssueLabels extends Table[IssueLabel]("ISSUE_LABEL") with IssueTemplate with LabelTemplate {
-  def * = userName ~ repositoryName ~ issueId ~ labelId <> (IssueLabel, IssueLabel.unapply _)
-  def byPrimaryKey(owner: String, repository: String, issueId: Int, labelId: Int) =
-    byIssue(owner, repository, issueId) && (this.labelId is labelId.bind)
+  object IssueLabels extends Table[IssueLabel]("ISSUE_LABEL") with IssueTemplate with LabelTemplate {
+    def * = userName ~ repositoryName ~ issueId ~ labelId <> (IssueLabel, IssueLabel.unapply _)
+    def byPrimaryKey(owner: String, repository: String, issueId: Int, labelId: Int) =
+      byIssue(owner, repository, issueId) && (this.labelId is labelId.bind)
+  }
 }
 
 case class IssueLabel(

--- a/src/main/scala/model/Labels.scala
+++ b/src/main/scala/model/Labels.scala
@@ -1,15 +1,17 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait LabelComponent extends LabelTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object Labels extends Table[Label]("LABEL") with LabelTemplate {
-  def labelName = column[String]("LABEL_NAME")
-  def color = column[String]("COLOR")
-  def * = userName ~ repositoryName ~ labelId ~ labelName ~ color <> (Label, Label.unapply _)
+  object Labels extends Table[Label]("LABEL") with LabelTemplate {
+    def labelName = column[String]("LABEL_NAME")
+    def color = column[String]("COLOR")
+    def * = userName ~ repositoryName ~ labelId ~ labelName ~ color <> (Label, Label.unapply _)
 
-  def ins = userName ~ repositoryName ~ labelName ~ color
-  def byPrimaryKey(owner: String, repository: String, labelId: Int) = byLabel(owner, repository, labelId)
-  def byPrimaryKey(userName: Column[String], repositoryName: Column[String], labelId: Column[Int]) = byLabel(userName, repositoryName, labelId)
+    def ins = userName ~ repositoryName ~ labelName ~ color
+    def byPrimaryKey(owner: String, repository: String, labelId: Int) = byLabel(owner, repository, labelId)
+    def byPrimaryKey(userName: Column[String], repositoryName: Column[String], labelId: Column[Int]) = byLabel(userName, repositoryName, labelId)
+  }
 }
 
 case class Label(

--- a/src/main/scala/model/Milestone.scala
+++ b/src/main/scala/model/Milestone.scala
@@ -1,17 +1,19 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait MilestoneComponent extends MilestoneTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object Milestones extends Table[Milestone]("MILESTONE") with MilestoneTemplate {
-  def title = column[String]("TITLE")
-  def description = column[String]("DESCRIPTION")
-  def dueDate = column[java.util.Date]("DUE_DATE")
-  def closedDate = column[java.util.Date]("CLOSED_DATE")
-  def * = userName ~ repositoryName ~ milestoneId ~ title ~ description.? ~ dueDate.? ~ closedDate.? <> (Milestone, Milestone.unapply _)
+  object Milestones extends Table[Milestone]("MILESTONE") with MilestoneTemplate {
+    def title = column[String]("TITLE")
+    def description = column[String]("DESCRIPTION")
+    def dueDate = column[java.util.Date]("DUE_DATE")
+    def closedDate = column[java.util.Date]("CLOSED_DATE")
+    def * = userName ~ repositoryName ~ milestoneId ~ title ~ description.? ~ dueDate.? ~ closedDate.? <> (Milestone, Milestone.unapply _)
 
-  def ins = userName ~ repositoryName ~ title ~ description.? ~ dueDate.? ~ closedDate.?
-  def byPrimaryKey(owner: String, repository: String, milestoneId: Int) = byMilestone(owner, repository, milestoneId)
-  def byPrimaryKey(userName: Column[String], repositoryName: Column[String], milestoneId: Column[Int]) = byMilestone(userName, repositoryName, milestoneId)
+    def ins = userName ~ repositoryName ~ title ~ description.? ~ dueDate.? ~ closedDate.?
+    def byPrimaryKey(owner: String, repository: String, milestoneId: Int) = byMilestone(owner, repository, milestoneId)
+    def byPrimaryKey(userName: Column[String], repositoryName: Column[String], milestoneId: Column[Int]) = byMilestone(userName, repositoryName, milestoneId)
+  }
 }
 
 case class Milestone(

--- a/src/main/scala/model/Profile.scala
+++ b/src/main/scala/model/Profile.scala
@@ -1,0 +1,10 @@
+package model
+
+import scala.slick.driver.ExtendedProfile
+
+trait Profile {
+  /**
+   * Note: `ExtendedProfile` will be replaced with `JdbcProfile` from Slick 2.0.0
+   */
+  val profile: ExtendedProfile
+}

--- a/src/main/scala/model/PullRequest.scala
+++ b/src/main/scala/model/PullRequest.scala
@@ -1,18 +1,20 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait PullRequestComponent extends IssueTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object PullRequests extends Table[PullRequest]("PULL_REQUEST") with IssueTemplate {
-  def branch = column[String]("BRANCH")
-  def requestUserName = column[String]("REQUEST_USER_NAME")
-  def requestRepositoryName = column[String]("REQUEST_REPOSITORY_NAME")
-  def requestBranch = column[String]("REQUEST_BRANCH")
-  def commitIdFrom = column[String]("COMMIT_ID_FROM")
-  def commitIdTo = column[String]("COMMIT_ID_TO")
-  def * = userName ~ repositoryName ~ issueId ~ branch ~ requestUserName ~ requestRepositoryName ~ requestBranch ~ commitIdFrom ~ commitIdTo <> (PullRequest, PullRequest.unapply _)
+  object PullRequests extends Table[PullRequest]("PULL_REQUEST") with IssueTemplate {
+    def branch = column[String]("BRANCH")
+    def requestUserName = column[String]("REQUEST_USER_NAME")
+    def requestRepositoryName = column[String]("REQUEST_REPOSITORY_NAME")
+    def requestBranch = column[String]("REQUEST_BRANCH")
+    def commitIdFrom = column[String]("COMMIT_ID_FROM")
+    def commitIdTo = column[String]("COMMIT_ID_TO")
+    def * = userName ~ repositoryName ~ issueId ~ branch ~ requestUserName ~ requestRepositoryName ~ requestBranch ~ commitIdFrom ~ commitIdTo <> (PullRequest, PullRequest.unapply _)
 
-  def byPrimaryKey(userName: String, repositoryName: String, issueId: Int) = byIssue(userName, repositoryName, issueId)
-  def byPrimaryKey(userName: Column[String], repositoryName: Column[String], issueId: Column[Int]) = byIssue(userName, repositoryName, issueId)
+    def byPrimaryKey(userName: String, repositoryName: String, issueId: Int) = byIssue(userName, repositoryName, issueId)
+    def byPrimaryKey(userName: Column[String], repositoryName: Column[String], issueId: Column[Int]) = byIssue(userName, repositoryName, issueId)
+  }
 }
 
 case class PullRequest(

--- a/src/main/scala/model/Repository.scala
+++ b/src/main/scala/model/Repository.scala
@@ -1,21 +1,23 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait RepositoryComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object Repositories extends Table[Repository]("REPOSITORY") with BasicTemplate {
-  def isPrivate = column[Boolean]("PRIVATE")
-  def description = column[String]("DESCRIPTION")
-  def defaultBranch = column[String]("DEFAULT_BRANCH")
-  def registeredDate = column[java.util.Date]("REGISTERED_DATE")
-  def updatedDate = column[java.util.Date]("UPDATED_DATE")
-  def lastActivityDate = column[java.util.Date]("LAST_ACTIVITY_DATE")
-  def originUserName = column[String]("ORIGIN_USER_NAME")
-  def originRepositoryName = column[String]("ORIGIN_REPOSITORY_NAME")
-  def parentUserName = column[String]("PARENT_USER_NAME")
-  def parentRepositoryName = column[String]("PARENT_REPOSITORY_NAME")
-  def * = userName ~ repositoryName ~ isPrivate ~ description.? ~ defaultBranch ~ registeredDate ~ updatedDate ~ lastActivityDate ~ originUserName.? ~ originRepositoryName.? ~ parentUserName.? ~ parentRepositoryName.? <> (Repository, Repository.unapply _)
+  object Repositories extends Table[Repository]("REPOSITORY") with BasicTemplate {
+    def isPrivate = column[Boolean]("PRIVATE")
+    def description = column[String]("DESCRIPTION")
+    def defaultBranch = column[String]("DEFAULT_BRANCH")
+    def registeredDate = column[java.util.Date]("REGISTERED_DATE")
+    def updatedDate = column[java.util.Date]("UPDATED_DATE")
+    def lastActivityDate = column[java.util.Date]("LAST_ACTIVITY_DATE")
+    def originUserName = column[String]("ORIGIN_USER_NAME")
+    def originRepositoryName = column[String]("ORIGIN_REPOSITORY_NAME")
+    def parentUserName = column[String]("PARENT_USER_NAME")
+    def parentRepositoryName = column[String]("PARENT_REPOSITORY_NAME")
+    def * = userName ~ repositoryName ~ isPrivate ~ description.? ~ defaultBranch ~ registeredDate ~ updatedDate ~ lastActivityDate ~ originUserName.? ~ originRepositoryName.? ~ parentUserName.? ~ parentRepositoryName.? <> (Repository, Repository.unapply _)
 
-  def byPrimaryKey(owner: String, repository: String) = byRepository(owner, repository)
+    def byPrimaryKey(owner: String, repository: String) = byRepository(owner, repository)
+  }
 }
 
 case class Repository(

--- a/src/main/scala/model/WebHook.scala
+++ b/src/main/scala/model/WebHook.scala
@@ -1,12 +1,14 @@
 package model
 
-import scala.slick.driver.H2Driver.simple._
+trait WebHookComponent extends BasicTemplateComponent { self: Profile =>
+  import profile.simple._
 
-object WebHooks extends Table[WebHook]("WEB_HOOK") with BasicTemplate {
-  def url = column[String]("URL")
-  def * = userName ~ repositoryName ~ url <> (WebHook, WebHook.unapply _)
+  object WebHooks extends Table[WebHook]("WEB_HOOK") with BasicTemplate {
+    def url = column[String]("URL")
+    def * = userName ~ repositoryName ~ url <> (WebHook, WebHook.unapply _)
 
-  def byPrimaryKey(owner: String, repository: String, url: String) = byRepository(owner, repository) && (this.url is url.bind)
+    def byPrimaryKey(owner: String, repository: String, url: String) = byRepository(owner, repository) && (this.url is url.bind)
+  }
 }
 
 case class WebHook(

--- a/src/main/scala/service/AccountService.scala
+++ b/src/main/scala/service/AccountService.scala
@@ -1,17 +1,17 @@
 package service
 
 import model._
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
 import service.SystemSettingsService.SystemSettings
 import util.StringUtil._
 import model.GroupMember
 import scala.Some
-import model.Account
 import util.LDAPUtil
 import org.slf4j.LoggerFactory
 
-trait AccountService {
+trait AccountService extends AccountComponent
+    with GroupMemberComponent with CollaboratorComponent with RepositoryComponent { self: Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
 
   private val logger = LoggerFactory.getLogger(classOf[AccountService])
 
@@ -149,5 +149,3 @@ trait AccountService {
   }
 
 }
-
-object AccountService extends AccountService

--- a/src/main/scala/service/ActivityService.scala
+++ b/src/main/scala/service/ActivityService.scala
@@ -1,10 +1,10 @@
 package service
 
 import model._
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
 
-trait ActivityService {
+trait ActivityService extends ActivityComponent with RepositoryComponent { self: Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
 
   def getActivitiesByUser(activityUserName: String, isPublic: Boolean): List[Activity] =
     Activities

--- a/src/main/scala/service/LabelsService.scala
+++ b/src/main/scala/service/LabelsService.scala
@@ -1,11 +1,10 @@
 package service
 
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
-
 import model._
 
-trait LabelsService {
+trait LabelsService extends LabelComponent with IssueLabelComponent { self: Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
 
   def getLabels(owner: String, repository: String): List[Label] =
     Query(Labels).filter(_.byRepository(owner, repository)).sortBy(_.labelName asc).list

--- a/src/main/scala/service/MilestonesService.scala
+++ b/src/main/scala/service/MilestonesService.scala
@@ -1,11 +1,10 @@
 package service
 
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
-
 import model._
 
-trait MilestonesService {
+trait MilestonesService extends MilestoneComponent with IssueComponent { self: Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
 
   def createMilestone(owner: String, repository: String, title: String, description: Option[String],
                       dueDate: Option[java.util.Date]): Unit =

--- a/src/main/scala/service/PullRequestService.scala
+++ b/src/main/scala/service/PullRequestService.scala
@@ -1,11 +1,11 @@
 package service
 
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
 import model._
 import util.ControlUtil._
 
-trait PullRequestService { self: IssuesService =>
+trait PullRequestService extends PullRequestComponent { self: IssuesService with Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
   import PullRequestService._
 
   def getPullRequest(owner: String, repository: String, issueId: Int): Option[(Issue, PullRequest)] =

--- a/src/main/scala/service/RepositoryService.scala
+++ b/src/main/scala/service/RepositoryService.scala
@@ -1,11 +1,14 @@
 package service
 
 import model._
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
 import util.JGitUtil
 
-trait RepositoryService { self: AccountService =>
+trait RepositoryService extends RepositoryComponent
+    with WebHookComponent with MilestoneComponent with IssueComponent with PullRequestComponent
+    with IssueCommentComponent with LabelComponent with IssueLabelComponent with CollaboratorComponent
+    with ActivityComponent { self: AccountService with Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
   import RepositoryService._
 
   /**

--- a/src/main/scala/service/RequestCache.scala
+++ b/src/main/scala/service/RequestCache.scala
@@ -1,6 +1,7 @@
 package service
 
 import model._
+import servlet.Database
 import service.SystemSettingsService.SystemSettings
 
 /**
@@ -18,19 +19,25 @@ trait RequestCache {
 
   def getIssue(userName: String, repositoryName: String, issueId: String)(implicit context: app.Context): Option[Issue] = {
     context.cache(s"issue.${userName}/${repositoryName}#${issueId}"){
-      new IssuesService {}.getIssue(userName, repositoryName, issueId)
+      new IssuesService with Profile {
+        val profile = Database.driver(context.request.getServletContext)
+      }.getIssue(userName, repositoryName, issueId)
     }
   }
 
   def getAccountByUserName(userName: String)(implicit context: app.Context): Option[Account] = {
     context.cache(s"account.${userName}"){
-      new AccountService {}.getAccountByUserName(userName)
+      new AccountService with Profile {
+        val profile = Database.driver(context.request.getServletContext)
+      }.getAccountByUserName(userName)
     }
   }
 
   def getAccountByMailAddress(mailAddress: String)(implicit context: app.Context): Option[Account] = {
     context.cache(s"account.${mailAddress}"){
-      new AccountService {}.getAccountByMailAddress(mailAddress)
+      new AccountService with Profile {
+        val profile = Database.driver(context.request.getServletContext)
+      }.getAccountByMailAddress(mailAddress)
     }
   }
 }

--- a/src/main/scala/service/WebHookService.scala
+++ b/src/main/scala/service/WebHookService.scala
@@ -1,8 +1,5 @@
 package service
 
-import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
-
 import model._
 import org.slf4j.LoggerFactory
 import service.RepositoryService.RepositoryInfo
@@ -15,7 +12,9 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.protocol.HTTP
 import org.apache.http.NameValuePair
 
-trait WebHookService {
+trait WebHookService extends WebHookComponent { self: Profile =>
+  import profile.simple._
+  import Database.threadLocalSession
   import WebHookService._
 
   private val logger = LoggerFactory.getLogger(classOf[WebHookService])

--- a/src/main/scala/servlet/BasicAuthenticationFilter.scala
+++ b/src/main/scala/servlet/BasicAuthenticationFilter.scala
@@ -2,16 +2,19 @@ package servlet
 
 import javax.servlet._
 import javax.servlet.http._
+import model.Profile
 import service.{SystemSettingsService, AccountService, RepositoryService}
 import org.slf4j.LoggerFactory
 import util.Implicits._
 import util.ControlUtil._
 import util.Keys
+import scala.slick.driver.ExtendedProfile
 
 /**
  * Provides BASIC Authentication for [[servlet.GitRepositoryServlet]].
  */
-class BasicAuthenticationFilter extends Filter with RepositoryService with AccountService with SystemSettingsService {
+class BasicAuthenticationFilter(override val profile: ExtendedProfile) extends Filter
+  with RepositoryService with AccountService with SystemSettingsService with Profile {
 
   private val logger = LoggerFactory.getLogger(classOf[BasicAuthenticationFilter])
 

--- a/src/main/scala/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/servlet/GitRepositoryServlet.scala
@@ -16,6 +16,9 @@ import service._
 import WebHookService._
 import org.eclipse.jgit.api.Git
 import util.JGitUtil.CommitInfo
+import scala.slick.driver.ExtendedProfile
+import model.Profile
+import scala.Some
 
 /**
  * Provides Git repository via HTTP.
@@ -80,7 +83,8 @@ class GitBucketReceivePackFactory extends ReceivePackFactory[HttpServletRequest]
       logger.debug("repository:" + owner + "/" + repository)
 
       if(!repository.endsWith(".wiki")){
-        receivePack.setPostReceiveHook(new CommitLogHook(owner, repository, pusher, baseUrl(request)))
+        receivePack.setPostReceiveHook(new CommitLogHook(
+          owner, repository, pusher, baseUrl(request), Database.driver(request.getServletContext)))
       }
       receivePack
     }
@@ -89,8 +93,8 @@ class GitBucketReceivePackFactory extends ReceivePackFactory[HttpServletRequest]
 
 import scala.collection.JavaConverters._
 
-class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: String) extends PostReceiveHook
-  with RepositoryService with AccountService with IssuesService with ActivityService with PullRequestService with WebHookService {
+class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: String, override val profile: ExtendedProfile) extends PostReceiveHook
+  with RepositoryService with AccountService with IssuesService with ActivityService with PullRequestService with WebHookService with Profile {
   
   private val logger = LoggerFactory.getLogger(classOf[CommitLogHook])
   

--- a/src/main/scala/servlet/TransactionFilter.scala
+++ b/src/main/scala/servlet/TransactionFilter.scala
@@ -31,8 +31,15 @@ class TransactionFilter extends Filter {
 }
 
 object Database {
-  def apply(context: ServletContext): scala.slick.session.Database =
+
+  import scala.slick.driver.ExtendedDriver
+  import scala.slick.session.Database
+
+  def apply(context: ServletContext): Database =
     scala.slick.session.Database.forURL(context.getInitParameter("db.url"),
         context.getInitParameter("db.user"),
         context.getInitParameter("db.password"))
+
+  def driver(context: ServletContext): ExtendedDriver = scala.slick.driver.H2Driver // TODO
+
 }

--- a/src/test/scala/service/AccountServiceSpec.scala
+++ b/src/test/scala/service/AccountServiceSpec.scala
@@ -1,5 +1,6 @@
 package service
 
+import model.Profile
 import org.specs2.mutable.Specification
 import java.util.Date
 import model.GroupMember
@@ -7,6 +8,9 @@ import model.GroupMember
 class AccountServiceSpec extends Specification with ServiceSpecBase {
 
   "AccountService" should {
+    val AccountService = new AccountService with Profile {
+      val profile = scala.slick.driver.H2Driver // we can mock it?
+    }
     val RootMailAddress = "root@localhost"
 
     "getAllUsers" in { withTestDB{


### PR DESCRIPTION
### Objective
Make database driver configurable, other than default [H2Driver](http://slick.typesafe.com/doc/2.0.0/api/scala/slick/driver/H2Driver.html), to support other databases such as [MySQL](http://slick.typesafe.com/doc/2.0.0/api/scala/slick/driver/MySQLDriver.html) and [PostgreSQL](http://slick.typesafe.com/doc/2.0.0/api/scala/slick/driver/PostgresDriver.html) in the future.

### Design
Note: I have implemented it with reference to [slick-examples](https://github.com/slick/slick-examples/blob/master/src/main/scala/com/typesafe/slick/examples/lifted/MultiDBCakeExample.scala).

Add `Profile` trait to combine it with `Table`.
```
trait Profile {
  val profile: ExtendedProfile
}
```

Import `Profile.profile.simple._` instead of `scala.slick.driver.H2Driver.simple._` directly in the table definition:
```
trait AccountComponent { self: Profile =>
  import profile.simple._
  object Accounts extends Table[Account]("ACCOUNT") {
    def userName = column[String]("USER_NAME", O PrimaryKey)
    ...
```

Services include corresponding `Component` to import the `Table` object.
```
trait AccountService extends AccountComponent { self: Profile =>
  def getAccountByUserName(userName: String, includeRemoved: Boolean = false): Option[Account] =
    Query(Accounts) filter(t => (t.userName is userName.bind) && (t.removed is false.bind, !includeRemoved)) firstOption
  ...
}
```

Now almost every controller requires an `ExtendedProfile` instance to inject into the services, combined with `Profile`.
```
class AccountController(override val profile: ExtendedProfile) extends AccountControllerBase
  with AccountService with RepositoryService with ActivityService with OneselfAuthenticator with Profile
```
```
class ScalatraBootstrap extends LifeCycle {
  override def init(context: ServletContext) {
    val driver = Database.driver(context)
    context.mount(new IndexController(driver), "/")
    context.mount(new SearchController(driver), "/")
    ...
```
