### PR TITLE
Allow LDAPS connections instead of only allowing TLS enabled connections

### DIFF
--- a/src/main/scala/app/SystemSettingsController.scala
+++ b/src/main/scala/app/SystemSettingsController.scala
@@ -41,6 +41,7 @@ trait SystemSettingsControllerBase extends ControllerBase {
         "fullNameAttribute"        -> trim(label("Full name attribute", optional(text()))),
         "mailAttribute"            -> trim(label("Mail address attribute", optional(text()))),
         "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
+        "ssl"					   -> trim(label("Enable SSL", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))
     )(Ldap.apply))
   )(SystemSettings.apply).verifying { settings =>

--- a/src/main/scala/app/SystemSettingsController.scala
+++ b/src/main/scala/app/SystemSettingsController.scala
@@ -41,7 +41,7 @@ trait SystemSettingsControllerBase extends ControllerBase {
         "fullNameAttribute"        -> trim(label("Full name attribute", optional(text()))),
         "mailAttribute"            -> trim(label("Mail address attribute", optional(text()))),
         "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
-        "ssl"					   -> trim(label("Enable SSL", optional(boolean()))),
+        "ssl"                      -> trim(label("Enable SSL", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))
     )(Ldap.apply))
   )(SystemSettings.apply).verifying { settings =>

--- a/src/main/scala/service/SystemSettingsService.scala
+++ b/src/main/scala/service/SystemSettingsService.scala
@@ -42,6 +42,7 @@ trait SystemSettingsService {
           ldap.fullNameAttribute.foreach(x => props.setProperty(LdapFullNameAttribute, x))
           ldap.mailAttribute.foreach(x => props.setProperty(LdapMailAddressAttribute, x))
           ldap.tls.foreach(x => props.setProperty(LdapTls, x.toString))
+          ldap.ssl.foreach(x => props.setProperty(LdapSsl, x.toString))
           ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
         }
       }
@@ -92,6 +93,7 @@ trait SystemSettingsService {
             getOptionValue(props, LdapFullNameAttribute, None),
             getOptionValue(props, LdapMailAddressAttribute, None),
             getOptionValue[Boolean](props, LdapTls, None),
+            getOptionValue[Boolean](props, LdapSsl, None),
             getOptionValue(props, LdapKeystore, None)))
         } else {
           None
@@ -134,6 +136,7 @@ object SystemSettingsService {
     fullNameAttribute: Option[String],
     mailAttribute: Option[String],
     tls: Option[Boolean],
+    ssl: Option[Boolean],
     keystore: Option[String])
 
   case class Smtp(
@@ -174,6 +177,7 @@ object SystemSettingsService {
   private val LdapFullNameAttribute = "ldap.fullname_attribute"
   private val LdapMailAddressAttribute = "ldap.mail_attribute"
   private val LdapTls = "ldap.tls"
+  private val LdapSsl = "ldap.ssl"
   private val LdapKeystore = "ldap.keystore"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A =

--- a/src/main/scala/util/LDAPUtil.scala
+++ b/src/main/scala/util/LDAPUtil.scala
@@ -48,6 +48,7 @@ object LDAPUtil {
       dn       = ldapSettings.bindDN.getOrElse(""),
       password = ldapSettings.bindPassword.getOrElse(""),
       tls      = ldapSettings.tls.getOrElse(false),
+      ssl	   = ldapSettings.ssl.getOrElse(false),
       keystore = ldapSettings.keystore.getOrElse(""),
       error    = "System LDAP authentication failed."
     ){ conn =>
@@ -65,6 +66,7 @@ object LDAPUtil {
       dn       = userDN,
       password = password,
       tls      = ldapSettings.tls.getOrElse(false),
+      ssl	   = ldapSettings.ssl.getOrElse(false),
       keystore = ldapSettings.keystore.getOrElse(""),
       error    = "User LDAP Authentication Failed."
     ){ conn =>
@@ -96,7 +98,7 @@ object LDAPUtil {
     }).replaceAll("[^a-zA-Z0-9\\-_.]", "").replaceAll("^[_\\-]", "")
   }
 
-  private def bind[A](host: String, port: Int, dn: String, password: String, tls: Boolean, keystore: String, error: String)
+  private def bind[A](host: String, port: Int, dn: String, password: String, tls: Boolean, ssl: Boolean, keystore: String, error: String)
                   (f: LDAPConnection => Either[String, A]): Either[String, A] = {
     if (tls) {
       // Dynamically set Sun as the security provider
@@ -109,7 +111,13 @@ object LDAPUtil {
       }
     }
 
-    val conn: LDAPConnection = new LDAPConnection(new LDAPJSSEStartTLSFactory())
+    val conn: LDAPConnection = 
+	if(ssl) {
+		new LDAPConnection(new LDAPJSSESecureSocketFactory()) 
+	}else {
+		new LDAPConnection(new LDAPJSSEStartTLSFactory())
+	}
+
     try {
       // Connect to the server
       conn.connect(host, port)

--- a/src/main/scala/util/LDAPUtil.scala
+++ b/src/main/scala/util/LDAPUtil.scala
@@ -48,7 +48,7 @@ object LDAPUtil {
       dn       = ldapSettings.bindDN.getOrElse(""),
       password = ldapSettings.bindPassword.getOrElse(""),
       tls      = ldapSettings.tls.getOrElse(false),
-      ssl	   = ldapSettings.ssl.getOrElse(false),
+      ssl      = ldapSettings.ssl.getOrElse(false),
       keystore = ldapSettings.keystore.getOrElse(""),
       error    = "System LDAP authentication failed."
     ){ conn =>
@@ -66,7 +66,7 @@ object LDAPUtil {
       dn       = userDN,
       password = password,
       tls      = ldapSettings.tls.getOrElse(false),
-      ssl	   = ldapSettings.ssl.getOrElse(false),
+      ssl      = ldapSettings.ssl.getOrElse(false),
       keystore = ldapSettings.keystore.getOrElse(""),
       error    = "User LDAP Authentication Failed."
     ){ conn =>

--- a/src/main/twirl/admin/system.scala.html
+++ b/src/main/twirl/admin/system.scala.html
@@ -170,6 +170,13 @@
               </div>
             </div>
             <div class="control-group">
+              <div class="controls">
+                <label class="checkbox">
+                  <input type="checkbox" name="ldap.ssl"@if(settings.ldap.flatMap(_.ssl).getOrElse(false)){ checked}/> Enable SSL
+                </label>
+              </div>
+            </div>
+            <div class="control-group">
               <label class="control-label" for="ldapBindDN">Keystore</label>
               <div class="controls">
                 <input type="text" id="ldapKeystore" name="ldap.keystore" value="@settings.ldap.map(_.keystore)"/>


### PR DESCRIPTION
I wanted to try out gitbucket today, since I am evaluating such tools for our company. My first task is always to connect my test subjects to our LDAP system (which only allows SSL connections). Since gitbucket only allows TLS connections this was an early showstopper. 
Using the TLS option also freezes authentication when used incorrectly.

My pull request will teach gitbucket to work properly with "real" SSL connections. 

Regards, Mario