### PR TITLE
Fix merge guide's text

### DIFF
--- a/src/main/twirl/pulls/mergeguide.scala.html
+++ b/src/main/twirl/pulls/mergeguide.scala.html
@@ -62,7 +62,7 @@
     <p>
       <span class="strong">Step 3:</span> Merge the changes and update the server
     </p>
-    @defining(s"git checkout master\ngit merge ${pullreq.requestUserName}-${pullreq.requestBranch}\ngit push origin ${pullreq.branch}"){ command =>
+    @defining(s"git checkout ${pullreq.branch}\ngit merge ${pullreq.requestUserName}-${pullreq.requestBranch}\ngit push origin ${pullreq.branch}"){ command =>
       @helper.html.copy("merge-command-copy-3", command){
         <pre style="width: 500px; float: left;">@command</pre>
       }


### PR DESCRIPTION
In merge guide's "Step 3", branch name of the checkout destination was "master" always.
Fix it, "master" is changed to `pullreq.branch`.