### PR TITLE
Fix blinking tooltips on side menu

### DIFF
--- a/src/main/twirl/menu.scala.html
+++ b/src/main/twirl/menu.scala.html
@@ -9,9 +9,9 @@
 @import view.helpers._
 
 @sidemenu(path: String, name: String, label: String, count: Int = 0) = {
-  <li @if(active == name){class="active"}>
+  <li @if(active == name){class="active"} @if(!expand){data-toggle="tooltip" data-placement="left" data-original-title="@label"}>
     <div class="@if(active == name){margin} else {gradient} pull-left"></div>
-    <a href="@url(repository)@path"@* @if(!expand){data-toggle="tooltip" data-placement="left" data-original-title="Code"}*@>
+    <a href="@url(repository)@path">
       @if(active == name){
         <img src="@assets/common/images/menu-@{name}-active.png">
       } else {

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -10,6 +10,7 @@ $(function(){
   // activate tooltip
   $('img[data-toggle=tooltip]').tooltip();
   $('a[data-toggle=tooltip]').tooltip();
+  $('li[data-toggle=tooltip]').tooltip();
 
   // anchor icon for markdown
   $('.markdown-head').mouseenter(function(e){


### PR DESCRIPTION
Move bootstrap tooltip up to the `li` element to fix the issue with blinking