### PR TITLE
fix javascript getter for plug-in system

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -54,8 +54,8 @@ class PluginRegistry {
 
   //def getJavaScripts(): List[(String, String)] = javaScripts.toList
 
-  def getJavaScript(currentPath: String): Option[String] = {
-    javaScripts.find(x => currentPath.matches(x._1)).map(_._2)
+  def getJavaScript(currentPath: String): List[String] = {
+    javaScripts.filter(x => currentPath.matches(x._1)).toList.map(_._2)
   }
 
   private case class GlobalAction(


### PR DESCRIPTION
The method `find` returns only one entry `Option[String]`.
So if there're more than one javascript (two plugins for example) registered to the same path, only the first one will be used.

This PR fix this issue allowing to use more than one javascript registered to the same path.