### PR TITLE
Fix font in line comments

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1045,7 +1045,7 @@ table.diff .add-comment:hover {
 }
 
 table.diff tbody tr.not-diff {
-    font-family: '"Helvetica Neue", Helvetica, Arial, sans-serif';
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 tr.not-diff .box {


### PR DESCRIPTION
Line comments on a diff were rendered in the browsers default font