### PR TITLE
fix #679 jquery-hashchange-plugin for jquery 1.9

### DIFF
--- a/src/main/webapp/assets/vendors/jquery/jquery.ba-hashchange.js
+++ b/src/main/webapp/assets/vendors/jquery/jquery.ba-hashchange.js
@@ -297,7 +297,7 @@
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvv REMOVE IF NOT SUPPORTING IE6/7/8 vvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    $.browser.msie && !supports_onhashchange && (function(){
+    /msie [\w.]+/i.test( navigator.appName ) && !supports_onhashchange && (function(){
       // Not only do IE6/7 need the "magical" Iframe treatment, but so does IE8
       // when running in "IE7 compatibility" mode.
       


### PR DESCRIPTION
fix #679 .

```
jquery.ba-hashchange.js:300 Uncaught TypeError: Cannot read property 'msie' 
```

in blob page.