### PR TITLE
Feature/improve file list performance

### DIFF
--- a/src/test/scala/gitbucket/core/util/GitSpecUtil.scala
+++ b/src/test/scala/gitbucket/core/util/GitSpecUtil.scala
@@ -1,0 +1,110 @@
+package gitbucket.core.util
+
+import gitbucket.core.model._
+import gitbucket.core.util.Directory._
+import gitbucket.core.util.ControlUtil._
+
+import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.dircache.DirCache
+import org.eclipse.jgit.lib._
+import org.eclipse.jgit.revwalk._
+import org.eclipse.jgit.treewalk._
+import org.eclipse.jgit.merge._
+import org.eclipse.jgit.errors._
+
+import java.nio.file._
+import java.util.Date
+import java.io.File
+
+object GitSpecUtil {
+  def withTestFolder[U](f: File => U) {
+    val folder = new File(System.getProperty("java.io.tmpdir"), "test-" + System.nanoTime)
+    if(!folder.mkdirs()){
+      throw new java.io.IOException("can't create folder "+folder.getAbsolutePath)
+    }
+    try {
+      f(folder)
+    } finally {
+      FileUtils.deleteQuietly(folder)
+    }
+  }
+  def withTestRepository[U](f: Git => U) = withTestFolder(folder => using(Git.open(createTestRepository(folder)))(f))
+  def createTestRepository(dir: File): File = {
+    RepositoryCache.clear()
+    FileUtils.deleteQuietly(dir)
+    Files.createDirectories(dir.toPath())
+    JGitUtil.initRepository(dir)
+    dir
+  }
+  def createFile(git: Git, branch: String, name: String, content: String,
+                 autorName: String = "dummy", autorEmail: String = "dummy@example.com",
+                 message: String = "test commit") {
+    val builder = DirCache.newInCore.builder()
+    val inserter = git.getRepository.newObjectInserter()
+    val headId = git.getRepository.resolve(branch + "^{commit}")
+    if(headId!=null){
+      JGitUtil.processTree(git, headId){ (path, tree) =>
+        if(name != path){
+          builder.add(JGitUtil.createDirCacheEntry(path, tree.getEntryFileMode, tree.getEntryObjectId))
+        }
+      }
+    }
+    builder.add(JGitUtil.createDirCacheEntry(name, FileMode.REGULAR_FILE,
+      inserter.insert(Constants.OBJ_BLOB, content.getBytes("UTF-8"))))
+    builder.finish()
+    JGitUtil.createNewCommit(git, inserter, headId, builder.getDirCache.writeTree(inserter),
+      branch, autorName, autorEmail, message)
+    inserter.flush()
+    inserter.release()
+  }
+  def getFile(git: Git, branch: String, path: String) = {
+    val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(branch))
+    val objectId = using(new TreeWalk(git.getRepository)) { walk =>
+      walk.addTree(revCommit.getTree)
+      walk.setRecursive(true)
+      @scala.annotation.tailrec
+      def _getPathObjectId: ObjectId = walk.next match {
+        case true if (walk.getPathString == path) => walk.getObjectId(0)
+        case true                                 => _getPathObjectId
+        case false                                => throw new Exception(s"not found ${branch} / ${path}")
+      }
+      _getPathObjectId
+    }
+    JGitUtil.getContentInfo(git, path, objectId)
+  }
+  def mergeAndCommit(git: Git, into:String, branch:String, message:String = null):Unit = {
+    val repository = git.getRepository
+    val merger = MergeStrategy.RECURSIVE.newMerger(repository, true)
+    val mergeBaseTip = repository.resolve(into)
+    val mergeTip = repository.resolve(branch)
+    val conflicted = try {
+      !merger.merge(mergeBaseTip, mergeTip)
+    } catch {
+      case e: NoMergeBaseException => true
+    }
+    if(conflicted){
+      throw new RuntimeException("conflict!")
+    }
+    val mergeTipCommit = using(new RevWalk( repository ))(_.parseCommit( mergeTip ))
+    val committer = mergeTipCommit.getCommitterIdent;
+    // creates merge commit
+    val mergeCommit = new CommitBuilder()
+    mergeCommit.setTreeId(merger.getResultTreeId)
+    mergeCommit.setParentIds(Array[ObjectId](mergeBaseTip, mergeTip): _*)
+    mergeCommit.setAuthor(committer)
+    mergeCommit.setCommitter(committer)
+    mergeCommit.setMessage(message)
+    // insertObject and got mergeCommit Object Id
+    val inserter = repository.newObjectInserter
+    val mergeCommitId = inserter.insert(mergeCommit)
+    inserter.flush()
+    inserter.release()
+    // update refs
+    val refUpdate = repository.updateRef(into)
+    refUpdate.setNewObjectId(mergeCommitId)
+    refUpdate.setForceUpdate(true)
+    refUpdate.setRefLogIdent(committer)
+    refUpdate.update()
+  }
+}

--- a/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
@@ -1,0 +1,96 @@
+package gitbucket.core.util
+
+import org.specs2.mutable._
+import GitSpecUtil._
+
+class JGitUtilSpec extends Specification {
+
+  "getFileList(git: Git, revision: String, path)" should {
+    withTestRepository { git =>
+      def list(branch: String, path: String) = try {
+        JGitUtil.getFileList(git, branch, path).map(finfo => (finfo.name, finfo.message, finfo.isDirectory))
+      } catch {
+        case e: NullPointerException => Nil
+      }
+      list("master", ".") mustEqual Nil
+      list("master", "dir/subdir") mustEqual Nil
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "README.md", "body1", message = "commit1")
+
+      list("master", ".") mustEqual List(("README.md", "commit1", false))
+      list("master", "dir/subdir") mustEqual Nil
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "README.md", "body2", message = "commit2")
+
+      list("master", ".") mustEqual List(("README.md", "commit2", false))
+      list("master", "dir/subdir") mustEqual Nil
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "dir/subdir/File3.md", "body3", message = "commit3")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit3", true), ("README.md", "commit2", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false))
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "dir/subdir/File4.md", "body4", message = "commit4")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit2", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "README5.md", "body5", message = "commit5")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit2", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      createFile(git, "master", "README.md", "body6", message = "commit6")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual Nil
+      list("branch", "dir/subdir") mustEqual Nil
+
+      git.branchCreate().setName("branch").setStartPoint("master").call()
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("branch", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+
+      createFile(git, "branch", "dir/subdir/File3.md", "body7", message = "commit7")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual List(("dir/subdir", "commit7", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("branch", "dir/subdir") mustEqual List(("File3.md", "commit7", false), ("File4.md", "commit4", false))
+
+      createFile(git, "master", "dir8/File8.md", "body8", message = "commit8")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("dir8", "commit8", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual List(("dir/subdir", "commit7", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("branch", "dir/subdir") mustEqual List(("File3.md", "commit7", false), ("File4.md", "commit4", false))
+
+      createFile(git, "branch", "dir/subdir9/File9.md", "body9", message = "commit9")
+
+      list("master", ".") mustEqual List(("dir/subdir", "commit4", true), ("dir8", "commit8", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit3", false), ("File4.md", "commit4", false))
+      list("branch", ".") mustEqual List(("dir", "commit9", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("branch", "dir/subdir") mustEqual List(("File3.md", "commit7", false), ("File4.md", "commit4", false))
+
+      mergeAndCommit(git, "master", "branch", message = "merge10")
+
+      list("master", ".") mustEqual List(("dir", "commit9", true), ("dir8", "commit8", true), ("README.md", "commit6", false), ("README5.md", "commit5", false))
+      list("master", "dir/subdir") mustEqual List(("File3.md", "commit7", false), ("File4.md", "commit4", false))
+    }
+  }
+}

--- a/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
@@ -7,11 +7,8 @@ class JGitUtilSpec extends Specification {
 
   "getFileList(git: Git, revision: String, path)" should {
     withTestRepository { git =>
-      def list(branch: String, path: String) = try {
+      def list(branch: String, path: String) =
         JGitUtil.getFileList(git, branch, path).map(finfo => (finfo.name, finfo.message, finfo.isDirectory))
-      } catch {
-        case e: NullPointerException => Nil
-      }
       list("master", ".") mustEqual Nil
       list("master", "dir/subdir") mustEqual Nil
       list("branch", ".") mustEqual Nil


### PR DESCRIPTION
gitbucket is seriously slow If project root has many files. because `JGitUtil.getFileList` is slow.
for example https://github.com/borisyankov/DefinitelyTyped.
getFileList('DefinitelyTyped', 'master', '.') take 199,654 milli seconds to get.

this pull request improvement for performance of method `JGitUtil.getFileList`.

getFileList('https://github.com/borisyankov/DefinitelyTyped','master','.') take 1820 ～ 1762 milli seconds.

( I found #376 after finished this work, and I measure performance on commit 62a6d743936f8cc7581a897b0700337e1b000194 , it take 2916 ～ 2660 milli seconds, my work has a meaning :)