### PR TITLE
fix/api context-path support

### DIFF
--- a/src/main/scala/gitbucket/core/util/Implicits.scala
+++ b/src/main/scala/gitbucket/core/util/Implicits.scala
@@ -63,10 +63,10 @@ object Implicits {
 
   implicit class RichRequest(request: HttpServletRequest){
 
-    def paths: Array[String] = (request.getRequestURI match{
-      case path if path.startsWith("/api/v3/repos/") => path.substring(13/* "/api/v3/repos".length */)
+    def paths: Array[String] = (request.getRequestURI.substring(request.getContextPath.length + 1) match{
+      case path if path.startsWith("api/v3/repos/") => path.substring(13/* "/api/v3/repos".length */)
       case path => path
-    }).substring(request.getContextPath.length + 1).split("/")
+    }).split("/")
 
     def hasQueryString: Boolean = request.getQueryString != null
 


### PR DESCRIPTION
When context-path is not '/', api `/api/v3/repos/*` works not correctly.

refs #684