### PR TITLE
Fix issue notifications

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -132,11 +132,11 @@ trait IssuesControllerBase extends ControllerBase {
 
         // call web hooks
         callIssuesWebHook("opened", repository, issue, context.baseUrl, context.loginAccount.get)
-      }
 
-      // notifications
-      Notifier().toNotify(repository, issueId, form.content.getOrElse("")){
-        Notifier.msgIssue(s"${context.baseUrl}/${owner}/${name}/issues/${issueId}")
+        // notifications
+        Notifier().toNotify(repository, issue, form.content.getOrElse("")){
+          Notifier.msgIssue(s"${context.baseUrl}/${owner}/${name}/issues/${issueId}")
+        }
       }
 
       redirect(s"/${owner}/${name}/issues/${issueId}")
@@ -418,13 +418,13 @@ trait IssuesControllerBase extends ControllerBase {
         Notifier() match {
           case f =>
             content foreach {
-              f.toNotify(repository, issueId, _){
+              f.toNotify(repository, issue, _){
                 Notifier.msgComment(s"${context.baseUrl}/${owner}/${name}/${
                   if(issue.isPullRequest) "pull" else "issues"}/${issueId}#comment-${commentId.get}")
               }
             }
             action foreach {
-              f.toNotify(repository, issueId, _){
+              f.toNotify(repository, issue, _){
                 Notifier.msgStatus(s"${context.baseUrl}/${owner}/${name}/issues/${issueId}")
               }
             }

--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -236,7 +236,7 @@ trait PullRequestsControllerBase extends ControllerBase {
             callPullRequestWebHook("closed", repository, issueId, context.baseUrl, context.loginAccount.get)
 
             // notifications
-            Notifier().toNotify(repository, issueId, "merge"){
+            Notifier().toNotify(repository, issue, "merge"){
               Notifier.msgStatus(s"${context.baseUrl}/${owner}/${name}/pull/${issueId}")
             }
 
@@ -395,8 +395,10 @@ trait PullRequestsControllerBase extends ControllerBase {
     callPullRequestWebHook("opened", repository, issueId, context.baseUrl, context.loginAccount.get)
 
     // notifications
-    Notifier().toNotify(repository, issueId, form.content.getOrElse("")){
-      Notifier.msgPullRequest(s"${context.baseUrl}/${repository.owner}/${repository.name}/pull/${issueId}")
+    getIssue(repository.owner, repository.name, issueId.toString) foreach { issue =>
+      Notifier().toNotify(repository, issue, form.content.getOrElse("")){
+        Notifier.msgPullRequest(s"${context.baseUrl}/${repository.owner}/${repository.name}/pull/${issueId}")
+      }
     }
 
     redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")


### PR DESCRIPTION
As explained by @troter on Issue #689, the Notification class can't notify (send email) when a new issue or pull request is created because the transaction wasn't committed yet, and the getIssue method inside the Notifier class runs in a different session.

To fix it I just pass the issue object instead of issueId to the Notifier class.