### PR TITLE
fix some api user is invalid, and add content-type on webhook

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -125,10 +125,10 @@ trait PullRequestsControllerBase extends ControllerBase {
     (for{
       issueId <- params("id").toIntOpt
       (issue, pullRequest) <- getPullRequest(repository.owner, repository.name, issueId)
-      users = getAccountsByUserNames(Set(repository.owner, pullRequest.requestUserName, issue.userName), Set())
+      users = getAccountsByUserNames(Set(repository.owner, pullRequest.requestUserName, issue.openedUserName), Set())
       baseOwner <- users.get(repository.owner)
       headOwner <- users.get(pullRequest.requestUserName)
-      issueUser <- users.get(issue.userName)
+      issueUser <- users.get(issue.openedUserName)
       headRepo  <- getRepository(pullRequest.requestUserName, pullRequest.requestRepositoryName, baseUrl)
     } yield {
       JsonFormat(ApiPullRequest(

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -32,8 +32,10 @@ trait ServiceSpecBase {
 
   def generateNewAccount(name:String)(implicit s:Session):Account = {
     AccountService.createAccount(name, name, name, s"${name}@example.com", false, None)
-    AccountService.getAccountByUserName(name).get
+    user(name)
   }
+
+  def user(name:String)(implicit s:Session):Account = AccountService.getAccountByUserName(name).get
 
   lazy val dummyService = new RepositoryService with AccountService with IssuesService with PullRequestService
     with CommitStatusService (){}
@@ -44,11 +46,11 @@ trait ServiceSpecBase {
     ac
   }
 
-  def generateNewIssue(userName:String, repositoryName:String, requestUserName:String="root")(implicit s:Session): Int = {
+  def generateNewIssue(userName:String, repositoryName:String, loginUser:String="root")(implicit s:Session): Int = {
     dummyService.createIssue(
       owner            = userName,
       repository       = repositoryName,
-      loginUser        = requestUserName,
+      loginUser        = loginUser,
       title            = "issue title",
       content          = None,
       assignedUserName = None,
@@ -56,10 +58,10 @@ trait ServiceSpecBase {
       isPullRequest    = true)
   }
 
-  def generateNewPullRequest(base:String, request:String)(implicit s:Session):(Issue, PullRequest) = {
+  def generateNewPullRequest(base:String, request:String, loginUser:String=null)(implicit s:Session):(Issue, PullRequest) = {
     val Array(baseUserName, baseRepositoryName, baesBranch)=base.split("/")
     val Array(requestUserName, requestRepositoryName, requestBranch)=request.split("/")
-    val issueId = generateNewIssue(baseUserName, baseRepositoryName, requestUserName)
+    val issueId = generateNewIssue(baseUserName, baseRepositoryName, Option(loginUser).getOrElse(requestUserName))
     dummyService.createPullRequest(
       originUserName        = baseUserName,
       originRepositoryName  = baseRepositoryName,

--- a/src/test/scala/gitbucket/core/service/WebHookServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/WebHookServiceSpec.scala
@@ -11,9 +11,10 @@ class WebHookServiceSpec extends Specification with ServiceSpecBase {
       val user1 = generateNewUserWithDBRepository("user1","repo1")
       val user2 = generateNewUserWithDBRepository("user2","repo2")
       val user3 = generateNewUserWithDBRepository("user3","repo3")
-      val (issue1, pullreq1) = generateNewPullRequest("user1/repo1/master1", "user2/repo2/master2")
-      val (issue3, pullreq3) = generateNewPullRequest("user3/repo3/master3", "user2/repo2/master2")
-      val (issue32, pullreq32) = generateNewPullRequest("user3/repo3/master32", "user2/repo2/master2")
+      val issueUser = user("root")
+      val (issue1, pullreq1) = generateNewPullRequest("user1/repo1/master1", "user2/repo2/master2", loginUser="root")
+      val (issue3, pullreq3) = generateNewPullRequest("user3/repo3/master3", "user2/repo2/master2", loginUser="root")
+      val (issue32, pullreq32) = generateNewPullRequest("user3/repo3/master32", "user2/repo2/master2", loginUser="root")
       generateNewPullRequest("user2/repo2/master2", "user1/repo1/master2")
       service.addWebHookURL("user1", "repo1", "webhook1-1")
       service.addWebHookURL("user1", "repo1", "webhook1-2")
@@ -25,18 +26,19 @@ class WebHookServiceSpec extends Specification with ServiceSpecBase {
       service.getPullRequestsByRequestForWebhook("user1","repo1","master1") must_== Map.empty
 
       var r = service.getPullRequestsByRequestForWebhook("user2","repo2","master2").mapValues(_.map(_.url).toSet)
+
       r.size must_== 3
-      r((issue1, pullreq1, user1, user2)) must_== Set("webhook1-1","webhook1-2")
-      r((issue3, pullreq3, user3, user2)) must_== Set("webhook3-1","webhook3-2")
-      r((issue32, pullreq32, user3, user2)) must_== Set("webhook3-1","webhook3-2")
+      r((issue1, issueUser, pullreq1, user1, user2)) must_== Set("webhook1-1","webhook1-2")
+      r((issue3, issueUser, pullreq3, user3, user2)) must_== Set("webhook3-1","webhook3-2")
+      r((issue32, issueUser, pullreq32, user3, user2)) must_== Set("webhook3-1","webhook3-2")
 
       // when closed, it not founds.
       service.updateClosed("user1","repo1",issue1.issueId, true)
 
       var r2 = service.getPullRequestsByRequestForWebhook("user2","repo2","master2").mapValues(_.map(_.url).toSet)
       r2.size must_== 2
-      r2((issue3, pullreq3, user3, user2)) must_== Set("webhook3-1","webhook3-2")
-      r2((issue32, pullreq32, user3, user2)) must_== Set("webhook3-1","webhook3-2")
+      r2((issue3, issueUser, pullreq3, user3, user2)) must_== Set("webhook3-1","webhook3-2")
+      r2((issue32, issueUser, pullreq32, user3, user2)) must_== Set("webhook3-1","webhook3-2")
     } }
   }
 }


### PR DESCRIPTION
fix some api user is invalid

  * issue.userName -> issue.openedUserName
  * issueComment.userName -> issueComment.commentedUserName

and add content-type on webhook request header. ( jenkins gprb need content-type since  1.16-7 https://github.com/jenkinsci/ghprb-plugin/commit/592a99a1ad032e63327feea08a78e34eca99b139 )

refs #684  