### PR TITLE
Fix basic auth read when anon access disabled

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/BasicAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/BasicAuthenticationFilter.scala
@@ -51,6 +51,9 @@ class BasicAuthenticationFilter extends Filter with RepositoryService with Accou
                             requireAuth(response)
                           }
                         }
+                        case Some(account) if (!settings.allowAnonymousAccess) => {
+                          chain.doFilter(req, wrappedResponse)
+                        }
                         case _ => requireAuth(response)
                       }
                     }


### PR DESCRIPTION
Basic authentication fails when not updating a public repository with the "Disable Anonymous Access" option enabled