### PR TITLE
Fix db connection error in dev mode

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,7 +1,7 @@
 
 import gitbucket.core.controller._
 import gitbucket.core.plugin.PluginRegistry
-import gitbucket.core.servlet.{AccessTokenAuthenticationFilter, BasicAuthenticationFilter, TransactionFilter}
+import gitbucket.core.servlet.{AccessTokenAuthenticationFilter, BasicAuthenticationFilter, Database, TransactionFilter}
 import gitbucket.core.util.Directory
 
 import java.util.EnumSet
@@ -46,5 +46,9 @@ class ScalatraBootstrap extends LifeCycle {
     if(!dir.exists){
       dir.mkdirs()
     }
+  }
+
+  override def destroy(context: ServletContext): Unit = {
+    Database.closeDataSource()
   }
 }

--- a/src/main/scala/gitbucket/core/servlet/TransactionFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/TransactionFilter.scala
@@ -39,22 +39,25 @@ object Database {
 
   private val logger = LoggerFactory.getLogger(Database.getClass)
 
-  private val db: SlickDatabase = {
-    val datasource = new ComboPooledDataSource
-
-    datasource.setDriverClass(DatabaseConfig.driver)
-    datasource.setJdbcUrl(DatabaseConfig.url)
-    datasource.setUser(DatabaseConfig.user)
-    datasource.setPassword(DatabaseConfig.password)
-
+  private val dataSource: ComboPooledDataSource = {
+    val ds = new ComboPooledDataSource
+    ds.setDriverClass(DatabaseConfig.driver)
+    ds.setJdbcUrl(DatabaseConfig.url)
+    ds.setUser(DatabaseConfig.user)
+    ds.setPassword(DatabaseConfig.password)
     logger.debug("load database connection pool")
+    ds
+  }
 
-    SlickDatabase.forDataSource(datasource)
+  private val db: SlickDatabase = {
+    SlickDatabase.forDataSource(dataSource)
   }
 
   def apply(): SlickDatabase = db
 
   def getSession(req: ServletRequest): Session =
     req.getAttribute(Keys.Request.DBSession).asInstanceOf[Session]
+
+  def closeDataSource(): Unit = dataSource.close
 
 }


### PR DESCRIPTION
Changes to close the no longer needed DB connections.

In the development, i think you maybe use `container:restart` or `~ ;copy-resources;aux-compile`.
However, since the H2 DB file is locked, can not normally operate.

The above problem will be fixed by this PR
