### PR TITLE
(refs #721)NullPointerException on getFileList

### DIFF
--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -287,9 +287,6 @@ object JGitUtil {
         }
       }
       revWalk.markStart(revCommit)
-      if(path != "."){
-        revWalk.setTreeFilter(PathFilter.create(path))
-      }
       val it = revWalk.iterator
       val lastCommit = it.next
       val nextParentsMap = Option(lastCommit).map(_.getParents.map(_ -> lastCommit).toMap).getOrElse(Map())

--- a/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
@@ -90,4 +90,14 @@ class JGitUtilSpec extends Specification {
       list("master", "dir/subdir") mustEqual List(("File3.md", "commit7", false), ("File4.md", "commit4", false))
     }
   }
+  "getFileList subfolder multi-origin (issue #721)" should {
+    withTestRepository { git =>
+      def list(branch: String, path: String) =
+        JGitUtil.getFileList(git, branch, path).map(finfo => (finfo.name, finfo.message, finfo.isDirectory))
+      createFile(git, "master", "README.md", "body1", message = "commit1")
+      createFile(git, "branch", "test/text2.txt", "body2", message = "commit2")
+      mergeAndCommit(git, "master", "branch", message = "merge3")
+      list("master", "test") mustEqual List(("text2.txt", "commit2", false))
+    }
+  }
 }


### PR DESCRIPTION
NullPointerException occured on getFileList
When branch has multi-origin and get sub-folder file list.
(see test https://github.com/takezoe/gitbucket/blob/ebc5219ce635d80c0bafd400e3c68a00879c0771/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala#L93 )