### PR TITLE
Fix typo

### DIFF
--- a/doc/directory.md
+++ b/doc/directory.md
@@ -6,7 +6,7 @@ This directory has following structure:
 
 ```
 * /HOME/gitbucket
-  * /repositoties
+  * /repositories 
     * /USER_NAME
       * / REPO_NAME.git (substance of repository. GitServlet sees this directory)
       * / REPO_NAME


### PR DESCRIPTION
Fix typo in the directory structure documentation: It should read Repositories, instead of Repositoties