### PR TITLE
fix test hook error

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -163,7 +163,7 @@ trait RepositorySettingsControllerBase extends ControllerBase {
   post("/:owner/:repository/settings/hooks/test", webHookForm)(ownerOnly { (form, repository) =>
     using(Git.open(getRepositoryDir(repository.owner, repository.name))){ git =>
       import scala.collection.JavaConverters._
-      val commits = git.log
+      val commits = if(repository.commitCount == 0) List.empty else git.log
         .add(git.getRepository.resolve(repository.repository.defaultBranch))
         .setMaxCount(3)
         .call.iterator.asScala.map(new CommitInfo(_))


### PR DESCRIPTION
When posting test hook on empty repository, Gitbucket throws NPE.

```
java.lang.NullPointerException
	at org.eclipse.jgit.lib.ObjectIdOwnerMap.get(ObjectIdOwnerMap.java:131)
	at org.eclipse.jgit.revwalk.RevWalk.lookupCommit(RevWalk.java:656)
	at org.eclipse.jgit.api.LogCommand.add(LogCommand.java:330)
	at org.eclipse.jgit.api.LogCommand.add(LogCommand.java:189)
	at gitbucket.core.controller.RepositorySettingsControllerBase$$anonfun$14$$anonfun$apply$14.apply(RepositorySettingsController.scala:167)
	at gitbucket.core.controller.RepositorySettingsControllerBase$$anonfun$14$$anonfun$apply$14.apply(RepositorySettingsController.scala:164)
	at gitbucket.core.util.ControlUtil$.using(ControlUtil.scala:26)
	at gitbucket.core.controller.RepositorySettingsControllerBase$$anonfun$14.apply(RepositorySettingsController.scala:164)
	at gitbucket.core.controller.RepositorySettingsControllerBase$$anonfun$14.apply(RepositorySettingsController.scala:163)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$ownerOnly$1$$anonfun$apply$2.apply(Authenticator.scala:34)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$ownerOnly$1$$anonfun$apply$2.apply(Authenticator.scala:34)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$gitbucket$core$util$OwnerAuthenticator$$authenticate$1$$anonfun$apply$3.apply(Authenticator.scala:41)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$gitbucket$core$util$OwnerAuthenticator$$authenticate$1$$anonfun$apply$3.apply(Authenticator.scala:39)
	at scala.Option.map(Option.scala:146)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$gitbucket$core$util$OwnerAuthenticator$$authenticate$1.apply(Authenticator.scala:39)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$gitbucket$core$util$OwnerAuthenticator$$authenticate$1.apply(Authenticator.scala:38)
	at gitbucket.core.util.ControlUtil$.defining(ControlUtil.scala:14)
	at gitbucket.core.util.OwnerAuthenticator$class.gitbucket$core$util$OwnerAuthenticator$$authenticate(Authenticator.scala:38)
	at gitbucket.core.util.OwnerAuthenticator$$anonfun$ownerOnly$1.apply(Authenticator.scala:34)
	at jp.sf.amateras.scalatra.forms.ClientSideValidationFormSupport$$anonfun$post$1$$anonfun$apply$2.apply(ClientSideValidationFormSupport.scala:24)
	at jp.sf.amateras.scalatra.forms.package$.withValidation(package.scala:21)
	at jp.sf.amateras.scalatra.forms.ClientSideValidationFormSupport$$anonfun$post$1.apply(ClientSideValidationFormSupport.scala:23)
	at org.scalatra.ScalatraBase$class.org$scalatra$ScalatraBase$$liftAction(ScalatraBase.scala:270)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:265)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:265)
	at org.scalatra.ApiFormats$class.withRouteMultiParams(ApiFormats.scala:182)
	at gitbucket.core.controller.ControllerBase.withRouteMultiParams(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$class.invoke(ScalatraBase.scala:264)
	at gitbucket.core.controller.ControllerBase.org$scalatra$json$JsonSupport$$super$invoke(ControllerBase.scala:27)
	at org.scalatra.json.JsonSupport$$anonfun$invoke$1.apply(JsonSupport.scala:88)
	at org.scalatra.json.JsonSupport$$anonfun$invoke$1.apply(JsonSupport.scala:82)
	at org.scalatra.ApiFormats$class.withRouteMultiParams(ApiFormats.scala:182)
	at gitbucket.core.controller.ControllerBase.withRouteMultiParams(ControllerBase.scala:27)
	at org.scalatra.json.JsonSupport$class.invoke(JsonSupport.scala:82)
	at gitbucket.core.controller.ControllerBase.invoke(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:240)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:238)
	at scala.Option.flatMap(Option.scala:171)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:238)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:237)
	at scala.collection.immutable.Stream.flatMap(Stream.scala:493)
	at org.scalatra.ScalatraBase$class.runRoutes(ScalatraBase.scala:237)
	at gitbucket.core.controller.ControllerBase.runRoutes(ControllerBase.scala:27)

        ...(continue)
```

fix above error.