### PR TITLE
fix login value for Webhook and API.

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiUser.scala
+++ b/src/main/scala/gitbucket/core/api/ApiUser.scala
@@ -27,7 +27,7 @@ case class ApiUser(
 
 object ApiUser{
   def apply(user: Account): ApiUser = ApiUser(
-    login      = user.fullName,
+    login      = user.userName,
     email      = user.mailAddress,
     `type`     = if(user.isGroupAccount){ "Organization" }else{ "User" },
     site_admin = user.isAdmin,


### PR DESCRIPTION
Hi.

Why `ApiUser#login` value is `Account#fullName`? (https://github.com/takezoe/gitbucket/blob/master/src/main/scala/gitbucket/core/api/ApiUser.scala#L30)

The issues are as follows.
* In webhook payloads, the API url is invalid.
* Not work `GitHub pull request builder plugin`. (https://github.com/takezoe/gitbucket/issues/684#issuecomment-99663083)