### PR TITLE
`_` is hidden by diff line

### DIFF
--- a/src/main/webapp/assets/vendors/jsdifflib/diffview.css
+++ b/src/main/webapp/assets/vendors/jsdifflib/diffview.css
@@ -66,7 +66,7 @@ table.diff thead th.texttitle {
 }
 table.diff tbody td {
 	padding:0px .4em;
-	padding-top:.4em;
+	padding-top:.2em;
 	vertical-align:top;
 	border-top: none;
 }


### PR DESCRIPTION
Fix height of diff line 

before diff area
![before](https://cloud.githubusercontent.com/assets/97468/7648070/4efe6674-fb19-11e4-9c76-cec544445b86.png)

after diff area
![after](https://cloud.githubusercontent.com/assets/97468/7648074/563dc722-fb19-11e4-8583-9a32414d1ad0.png)
