### PR TITLE
Add pre-tag horizontal scroll on markdown

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1225,6 +1225,8 @@ div.markdown-body pre {
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 12px;
   white-space: pre;
+  word-wrap: normal;
+  overflow: auto;
 }
 
 div.markdown-body code {


### PR DESCRIPTION
pre tag on markdown is disabled horizontal scroll.
but, I want to horizontal scroll. (eg. SQL, HTML, command line, and just like GitHub)

before.
![2015-05-20 18 01 15](https://cloud.githubusercontent.com/assets/97468/7722766/47a558d4-ff1e-11e4-88cb-076627de3bfb.png)

after.
![2015-05-20 18 01 44](https://cloud.githubusercontent.com/assets/97468/7722771/507b28bc-ff1e-11e4-919c-381378fb3197.png)
