### PR TITLE
fix diff ignore space

### DIFF
--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -109,7 +109,7 @@ function JsDiffRender(params){
   var headTextLines = (params.newText==="")?[]:params.newText.split(/\r\n|\r|\n/);
   var sm, ctx;
   if(params.ignoreSpace){
-    var ignoreSpace = function(a){ return a.replace(/\s+/,' ').replace(/^\s+|\s+$/,''); };
+    var ignoreSpace = function(a){ return a.replace(/\s+/g,''); };
     sm = new difflib.SequenceMatcher(
       $.map(baseTextLines, ignoreSpace),
       $.map(headTextLines, ignoreSpace));


### PR DESCRIPTION
Now, diff ignore-space don't ignore difference between space and non-space.
For example, `a = 1` and `a=1`.

this patch is fix it.