### PR TITLE
Fixed bashism 'source'

### DIFF
--- a/README-bashism.md
+++ b/README-bashism.md
@@ -1,0 +1,13 @@
+Running `./sbt.sh` emits `./sbt.sh: 2: ./sbt.sh: source: not found`
+====
+
+This is due to the usage of `source` within the scripts.
+
+There are two potential fixes:
+
+* Change `#!/bin/sh` to `#!/bin/bash`
+* Change `source` to `.`
+
+I'm doing the ladder one...
+
+* `find . -name "*.sh*|xargs -n1 sed -i "s/source /. /"`

--- a/release/deploy-assembly-jar.sh
+++ b/release/deploy-assembly-jar.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source ../env.sh
+. ../env.sh
 
 cd ../
 ./sbt.sh clean assembly

--- a/release/make-release-war.sh
+++ b/release/make-release-war.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-source ../env.sh
+. ../env.sh
 ant -f build.xml all

--- a/sbt.sh
+++ b/sbt.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-source ./env.sh
+. ./env.sh
 java -Dsbt.log.noformat=true -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -Xmx512M -Xss2M -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -jar `dirname $0`/sbt-launch-0.13.8.jar "$@"


### PR DESCRIPTION
Running `./sbt.sh` emits `./sbt.sh: 2: ./sbt.sh: source: not found`
====

This is due to the usage of `source` within the scripts.

There are two potential fixes:

* Change `#!/bin/sh` to `#!/bin/bash`
* Change `source` to `.`

I'm doing the ladder one...

* `find . -name "*.sh*|xargs -n1 sed -i "s/source /. /"`
