### PR TITLE
doc change: build.xml -> release/build.xml

### DIFF
--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,9 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.
+To build executable war file, run
+
+*  `. ./env.sh`
+*  `ant -f release/build.xml all`
+
+at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,4 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run Ant at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in build.xml if you want to run it on Linux.
+To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in release/build.xml if you want to run it on Linux.

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,4 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in release/build.xml if you want to run it on Linux.
+To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.


### PR DESCRIPTION
The doc references a top level build.xml, which doesn't exist any more.