### PR TITLE
Linux Ubuntu1404

### DIFF
--- a/README-bashism.md
+++ b/README-bashism.md
@@ -1,0 +1,13 @@
+Running `./sbt.sh` emits `./sbt.sh: 2: ./sbt.sh: source: not found`
+====
+
+This is due to the usage of `source` within the scripts.
+
+There are two potential fixes:
+
+* Change `#!/bin/sh` to `#!/bin/bash`
+* Change `source` to `.`
+
+I'm doing the ladder one...
+
+* `find . -name "*.sh*|xargs -n1 sed -i "s/source /. /"`

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,9 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.
+To build executable war file, run
+
+*  `. ./env.sh`
+*  `ant -f release/build.xml all`
+
+at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,4 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run Ant at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in build.xml if you want to run it on Linux.
+To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in release/build.xml if you want to run it on Linux.

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -16,8 +16,20 @@ for Developers
 --------
 If you want to modify source code and confirm it, you can run GitBucket in auto reloading mode as following:
 
+Windows:
+
 ```
 C:\gitbucket> sbt
+...
+> container:start
+...
+> ~ ;copy-resources;aux-compile
+```
+
+Linux:
+
+```
+~/gitbucket$ ./sbt.sh
 ...
 > container:start
 ...
@@ -29,15 +41,23 @@ Build war file
 
 To build war file, run the following command:
 
+Windows:
+
 ```
 C:\gitbucket> sbt package
+```
+
+Linux:
+
+```
+~/gitbucket$ ./sbt.sh package
 ```
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
 To build executable war file, run
 
-*  `. ./env.sh`
-*  `ant -f release/build.xml all`
+*  Windows: `???`
+*  Linux: `./release/make-release-war.sh`
 
 at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.

--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -35,4 +35,4 @@ C:\gitbucket> sbt package
 
 `gitbucket_2.11-x.x.x.war` is generated into `target/scala-2.11`.
 
-To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact. Please note the current build.xml works on Windows only. Replace `sbt.bat` with `sbt.sh` in release/build.xml if you want to run it on Linux.
+To build executable war file, run `ant -f release/build.xml` at the top of the source tree. It generates executable `gitbucket.war` into `target/scala-2.11`. We release this war file as release artifact.

--- a/release/deploy-assembly-jar.sh
+++ b/release/deploy-assembly-jar.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source ../env.sh
+. ../env.sh
 
 cd ../
 ./sbt.sh clean assembly

--- a/release/make-release-war.sh
+++ b/release/make-release-war.sh
@@ -1,3 +1,15 @@
 #!/bin/sh
-. ../env.sh
-ant -f build.xml all
+D="$(dirname "$0")"
+D="$(cd "${D}"; pwd)"
+DD="$(dirname "${D}")"
+(
+  for f in "${DD}/env.sh" "${D}/build.xml"; do
+    if [ ! -s "${f}" ]; then
+      echo >&2 "$0: Unable to access file '${f}'"
+      exit 1
+    fi
+  done
+  cd "${DD}"
+  . "${DD}/env.sh"
+  ant -f "${D}/build.xml" all
+)

--- a/release/make-release-war.sh
+++ b/release/make-release-war.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-source ../env.sh
+. ../env.sh
 ant -f build.xml all

--- a/sbt.sh
+++ b/sbt.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-source ./env.sh
+. ./env.sh
 java -Dsbt.log.noformat=true -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -Xmx512M -Xss2M -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -jar `dirname $0`/sbt-launch-0.13.8.jar "$@"


### PR DESCRIPTION
This pull request makes the release process work on linux.

* it fixes the source bashism (see separate pull request #793)
* it fixes the script "make-release-war.sh"
* it fixes the doc "how_to_run.md"

Within "how_to_run.md", the description on how to do a release on windows is missing.
Running "Ant at the top of the source tree" doesn't work since there is no build.xml any more...