### PR TITLE
New PRs in forked repositories default to comparing with parent repository's default branch

### DIFF
--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -160,6 +160,12 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
    */
   def encodeRefName(value: String): String = StringUtil.urlEncode(value).replace("%2F", "/")
 
+  /**
+   * Url encode except '/' and ':'
+   */
+  def encodeCompareBranch(value: String) =
+    StringUtil.urlEncode(value).replace("%2F", "/").replace("%3A", ":")
+
   def urlEncode(value: String): String = StringUtil.urlEncode(value)
 
   def urlEncode(value: Option[String]): String = value.map(urlEncode).getOrElse("")

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.{Date, Locale, TimeZone}
 
 import gitbucket.core.controller.Context
-import gitbucket.core.model.CommitState
+import gitbucket.core.model.{CommitState, Repository}
 import gitbucket.core.plugin.{RenderRequest, PluginRegistry, Renderer}
 import gitbucket.core.service.{RepositoryService, RequestCache}
 import gitbucket.core.util.{FileUtil, JGitUtil, StringUtil}
@@ -163,6 +163,18 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   def urlEncode(value: String): String = StringUtil.urlEncode(value)
 
   def urlEncode(value: Option[String]): String = value.map(urlEncode).getOrElse("")
+
+  /**
+   * The default origin (branch or remote:branch pair) branches are compared to.
+   *
+   * There are two cases: when the repo is a fork and when the repo is not a
+   * fork.
+   *
+   * For a fork, the default ref is parentUserName:defaultBranch.
+   * For a non fork, the default ref is defaultBranch.
+   */
+  def repositoryDefaultCompareOrigin(repo: Repository): String =
+    repo.parentUserName.map(n => s"$n:${repo.defaultBranch}").getOrElse(repo.defaultBranch)
 
   /**
    * Generates the url to the repository.

--- a/src/main/twirl/gitbucket/core/repo/branches.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/branches.scala.html
@@ -30,9 +30,9 @@
                   }
                 }.getOrElse{
                   @if(context.loginAccount.isDefined){
-                    <a href="@url(repository)/compare/@{encodeRefName(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeRefName(branch.name)}?expand=1" class="btn btn-small">New Pull Request</a>
+                    <a href="@url(repository)/compare/@{encodeCompareBranch(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeCompareBranch(branch.name)}?expand=1" class="btn btn-small">New Pull Request</a>
                   }else{
-                    <a href="@url(repository)/compare/@{encodeRefName(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeRefName(branch.name)}" class="btn btn-small">Compare</a>
+                    <a href="@url(repository)/compare/@{encodeCompareBranch(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeCompareBranch(branch.name)}" class="btn btn-small">Compare</a>
                   }
                 }
                 @if(hasWritePermission){

--- a/src/main/twirl/gitbucket/core/repo/branches.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/branches.scala.html
@@ -30,9 +30,9 @@
                   }
                 }.getOrElse{
                   @if(context.loginAccount.isDefined){
-                    <a href="@url(repository)/compare/@{encodeRefName(repository.repository.defaultBranch)}...@{encodeRefName(branch.name)}?expand=1" class="btn btn-small">New Pull Request</a>
+                    <a href="@url(repository)/compare/@{encodeRefName(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeRefName(branch.name)}?expand=1" class="btn btn-small">New Pull Request</a>
                   }else{
-                    <a href="@url(repository)/compare/@{encodeRefName(repository.repository.defaultBranch)}...@{encodeRefName(branch.name)}" class="btn btn-small">Compare</a>
+                    <a href="@url(repository)/compare/@{encodeRefName(repositoryDefaultCompareOrigin(repository.repository))}...@{encodeRefName(branch.name)}" class="btn btn-small">Compare</a>
                   }
                 }
                 @if(hasWritePermission){

--- a/src/test/scala/gitbucket/core/view/HelpersSpec.scala
+++ b/src/test/scala/gitbucket/core/view/HelpersSpec.scala
@@ -34,4 +34,18 @@ class HelpersSpec extends Specification {
       helpers.repositoryDefaultCompareOrigin(repo) mustEqual "parent-user:some-branch"
     }
   }
+
+  "encodeCompareBranch" should {
+    "not uri encode /" in {
+      helpers.encodeCompareBranch("foo/bar#baz") mustEqual "foo/bar%23baz"
+    }
+
+    "not uri encode :" in {
+      helpers.encodeCompareBranch("foo:bar#baz") mustEqual "foo:bar%23baz"
+    }
+
+    "uri encode special characters" in {
+      helpers.encodeCompareBranch("!#$&'()+,;=?@[]") mustEqual "%21%23%24%26%27%28%29%2B%2C%3B%3D%3F%40%5B%5D"
+    }
+  }
 }

--- a/src/test/scala/gitbucket/core/view/HelpersSpec.scala
+++ b/src/test/scala/gitbucket/core/view/HelpersSpec.scala
@@ -1,0 +1,37 @@
+package gitbucket.core.view
+
+import org.specs2.mutable._
+import gitbucket.core.model.Repository
+import java.util.Date
+
+class HelpersSpec extends Specification {
+  def repository(defaultBranch: String, parentUserName: Option[String]) =
+    Repository(
+      userName = "some-user",
+      repositoryName = "some-repo",
+      isPrivate = false,
+      description = None,
+      defaultBranch = defaultBranch,
+      parentUserName = parentUserName,
+      parentRepositoryName = Some("some-repo"),
+      registeredDate = new Date(),
+      updatedDate = new Date(),
+      lastActivityDate = new Date(),
+      originUserName = Some("some-other-user"),
+      originRepositoryName = Some("some-repo")
+    )
+
+  "repositoryDefaultCompareOrigin" should {
+    "return default branch when not fork" in {
+      val repo = repository("master", None)
+
+      helpers.repositoryDefaultCompareOrigin(repo) mustEqual "master"
+    }
+
+    "return [upstream]:[branch] when a fork" in {
+      val repo = repository("some-branch", Some("parent-user"))
+
+      helpers.repositoryDefaultCompareOrigin(repo) mustEqual "parent-user:some-branch"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the improvement requested in #668. 

When looking at the branches of a repository, there are buttons that allow you to compare branches or create a PR.

If the current repo is not a fork, clicking one of those buttons compares the given branch with the default branch.

If the current repo is a fork, clicking one of those buttons compares the given branch with the default branch of the parent (upstream) repository.