### PR TITLE
Added nice titles to atom feeds

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/feed.scala.xml
+++ b/src/main/twirl/gitbucket/core/helper/feed.scala.xml
@@ -16,7 +16,7 @@
     <published>@datetimeRFC3339(activity.activityDate)</published>
     <updated>@datetimeRFC3339(activity.activityDate)</updated>
     <link type="text/html" rel="alternate" href="@context.baseUrl/@activity.userName/@activity.repositoryName" />
-    <title type="html">@activity.activityType</title>
+    <title type="html">@activityMessage(activity.message)</title>
     <author>
       <name>@activity.activityUserName</name>
       <uri>@url(activity.activityUserName)</uri>


### PR DESCRIPTION
Originally titles in the atom feed used the activity type. This gave no useful information. The user had to open the news item to see what was going on. Now, the title is the activity's message rendered to html.

This fixes #481