### PR TITLE
Fix duplicated Content-Type

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/AccessTokenAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/AccessTokenAuthenticationFilter.scala
@@ -33,7 +33,7 @@ class AccessTokenAuthenticationFilter extends Filter with AccessTokenService {
       case None => chain.doFilter(req, res)
       case Some(Left(_)) => {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
-        response.setContentType("Content-Type: application/json; charset=utf-8")
+        response.setContentType("application/json; charset=utf-8")
         val w = response.getWriter()
         w.print("""{ "message": "Bad credentials" }""")
         w.close()


### PR DESCRIPTION
When you request to the web api with an incorrect token, GitBucket return the duplicated Content-Type.