### PR TITLE
add export functionality via system settings page and via URL, close …

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -1,17 +1,25 @@
 package gitbucket.core.controller
 
+import java.io.File
+
 import gitbucket.core.admin.html
 import gitbucket.core.service.{AccountService, SystemSettingsService}
+import gitbucket.core.servlet.Database
 import gitbucket.core.util.AdminAuthenticator
 import gitbucket.core.ssh.SshServer
+import gitbucket.core.util.Directory._
 import SystemSettingsService._
 import jp.sf.amateras.scalatra.forms._
+import org.scalatra.Ok
+import org.slf4j.LoggerFactory
 
 class SystemSettingsController extends SystemSettingsControllerBase
   with AccountService with AdminAuthenticator
 
 trait SystemSettingsControllerBase extends ControllerBase {
   self: AccountService with AdminAuthenticator =>
+
+  private val logger = LoggerFactory.getLogger(classOf[SystemSettingsControllerBase])
 
   private val form = mapping(
     "baseUrl"                  -> trim(label("Base URL", optional(text()))),
@@ -59,6 +67,28 @@ trait SystemSettingsControllerBase extends ControllerBase {
   )(PluginForm.apply)
 
   case class PluginForm(pluginIds: List[String])
+
+  def exportDatabase: Unit = {
+    val session = Database.getSession(request)
+    val conn = session.conn
+    val exportFile = new File(GitBucketHome, "export.zip")
+
+    logger.info("exporting database to {}", exportFile)
+
+    conn.prepareStatement("BACKUP TO '" + exportFile + "'").execute();
+  }
+
+
+  get("/export") {
+    exportDatabase
+    Ok("done")
+  }
+  post("/export") {
+    exportDatabase
+    flash += "info" -> "Database has been exported."
+    redirect("/admin/system")
+  }
+
 
   get("/admin/system")(adminOnly {
     html.system(flash.get("info"))

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -71,24 +71,23 @@ trait SystemSettingsControllerBase extends ControllerBase {
   def exportDatabase: Unit = {
     val session = Database.getSession(request)
     val conn = session.conn
-    val exportFile = new File(GitBucketHome, "export.zip")
+    val exportFile = new File(GitBucketHome, "gitbucket-database-backup.zip")
 
     logger.info("exporting database to {}", exportFile)
 
     conn.prepareStatement("BACKUP TO '" + exportFile + "'").execute();
   }
 
-
-  get("/export") {
+  get("/database/backup") {
     exportDatabase
     Ok("done")
   }
-  post("/export") {
+
+  post("/database/backup") {
     exportDatabase
     flash += "info" -> "Database has been exported."
     redirect("/admin/system")
   }
-
 
   get("/admin/system")(adminOnly {
     html.system(flash.get("info"))

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -5,13 +5,13 @@
 @html.main("System Settings"){
   @menu("system"){
     @helper.html.information(info)
-    <form action="@path/export" method="POST">
+    <form action="@path/database/backup" method="POST">
         <div class="box">
           <div class="box-header">Database export</div>
           <div class="box-content">
-            <label><span class="strong">Database export file:</span>@GitBucketHome/export.zip</label>
+            <label><span class="strong">Database export file:</span>@GitBucketHome/gitbucket-database-backup.zip</label>
             <p class="muted">
-              Allows to export the database content. The same action can be achieved via a remote call to @path/export
+              Allows to export the database content. The same action can be achieved via an HTTP GET call to @path/database/backup
             </p>
 
             <fieldset>

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -5,6 +5,21 @@
 @html.main("System Settings"){
   @menu("system"){
     @helper.html.information(info)
+    <form action="@path/export" method="POST">
+        <div class="box">
+          <div class="box-header">Database export</div>
+          <div class="box-content">
+            <label><span class="strong">Database export file:</span>@GitBucketHome/export.zip</label>
+            <p class="muted">
+              Allows to export the database content. The same action can be achieved via a remote call to @path/export
+            </p>
+
+            <fieldset>
+                <input type="submit" class="btn btn-primary" value="Export database"/>
+              </fieldset>
+          </div>
+        </div>
+    </form>
     <form action="@path/admin/system" method="POST" validate="true">
       <div class="box">
         <div class="box-header">System Settings</div>


### PR DESCRIPTION
Hi,

find enclosed a small contribution to gitbucket.
It consists in providing a way to export the HSQLDB database. Such a functionality allows then setup some backup mechanisms for gitbucket.

I provide currently 2 ways to backup the database:

1. via the System Administration GUI / System Settings : a new panel is added for database export
![image](https://cloud.githubusercontent.com/assets/1119660/8959216/d7a24be6-3609-11e5-94d8-3732fd7fb819.png)
1. via an HTTP GET on http://server:port/export

PS: I am totally new to scala world (pure java/jee developper) so by advance I apologize if I didn't respected some scala conventions.