### PR TITLE
solve #820 too long messages

### DIFF
--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -57,7 +57,16 @@ object JGitUtil {
    * @param linkUrl the url of submodule
    */
   case class FileInfo(id: ObjectId, isDirectory: Boolean, name: String, message: String, commitId: String,
-                      time: Date, author: String, mailAddress: String, linkUrl: Option[String])
+                      time: Date, author: String, mailAddress: String, linkUrl: Option[String]) {
+    def shortMessage: String = {
+      val maxLength = 70
+      if (message.length() > maxLength) {
+        message.substring(0, maxLength) + "..."
+      } else {
+        message
+      }
+    }
+  }
 
   /**
    * The commit data.

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -118,7 +118,7 @@
         }
         </td>
         <td class="mute">
-          <a href="@url(repository)/commit/@file.commitId" class="commit-message">@link(file.message, repository)</a>
+          <a href="@url(repository)/commit/@file.commitId" class="commit-message">@link(file.shortMessage, repository)</a>
           [@user(file.author, file.mailAddress)]
         </td>
         <td style="text-align: right;">@helper.html.datetimeago(file.time, false)</td>


### PR DESCRIPTION
small enhancement to shorten long commit messages in the file list of repositories (#820)

![image](https://cloud.githubusercontent.com/assets/1119660/8961247/62e64fd6-3614-11e5-87e7-35d6d71304cd.png)
