### PR TITLE
Increase container width

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -155,7 +155,7 @@ div.head div.forked {
 }
 
 div.container {
-  width: 920px;
+  width: 980px;
 }
 
 div.container-wide {


### PR DESCRIPTION
Matches Github's container width of 980px.