### PR TITLE
give an id to system admin menu container to allow plugin extension

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/menu.scala.html
@@ -4,7 +4,7 @@
   <div class="row-fluid">
     <div class="span3">
       <div class="box">
-        <ul class="nav nav-tabs nav-stacked side-menu">
+        <ul class="nav nav-tabs nav-stacked side-menu" id="system-admin-menu-container">
           <li@if(active=="users"){ class="active"}>
             <a href="@path/admin/users">User Management</a>
           </li>


### PR DESCRIPTION
Having an id on the container of admin links allows a plugin to enhance it.

This will be used for example by [McFoggy/gitbucket-announce-plugin](https://github.com/McFoggy/gitbucket-announce-plugin)