### PR TITLE
Update main.scala.html

### DIFF
--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -66,7 +66,7 @@
             <div class="nav-collapse collapse pull-right header-menu">
               @if(loginAccount.isDefined){
                 <div class="btn-group" style="margin-top: 0px;">
-                  <a class="dropdown-toggle menu" data-toggle="dropdown" href="#"><i class="octicon octicon-plus" style="font-size: 20px; vertical-align: top; margin-top: 10px;"></i><span class="caret" style="vertical-align: middle;"></span></a>
+                  <a class="dropdown-toggle menu" data-toggle="dropdown" href="#"><i class="octicon octicon-plus" style="font-size: 20px; vertical-align: middle;height:20px !important;"></i><span class="caret" style="vertical-align: middle;"></span></a>
                   <ul class="dropdown-menu pull-right">
                     <li><a href="@path/new">New repository</a></li>
                     <li><a href="@path/groups/new">New group</a></li>
@@ -75,6 +75,7 @@
                 <div class="btn-group" style="margin-top: 0px;">
                   <a class="dropdown-toggle menu" data-toggle="dropdown" href="#" data-toggle="tooltip" data-placement="bottom" title="Signed is as @loginAccount.get.userName">@avatar(loginAccount.get.userName, 16)<span class="caret" style="vertical-align: middle;"></span></a>
                   <ul class="dropdown-menu pull-right">
+                    <li><a href="@url(loginAccount.get.userName)">Your profile</a></li>
                     <li><a href="@url(loginAccount.get.userName)/_edit">Account settings</a></li>
                     @if(loginAccount.get.isAdmin){
                       <li><a href="@path/admin/users">System administration</a></li>


### PR DESCRIPTION
1. fix header plus dropdown menu display bug in safari

When in safari, the header "+" menu is not middle in vertical.

2. add 'Your profile' in user dropdown menu

User dropdown menu in github has "Your profile",but gitbucket lack of this menu and has no entrance to your profile.