### PR TITLE
Updated to fix truncated name in JSON: watchers_coun

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiRepository.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepository.scala
@@ -15,7 +15,7 @@ case class ApiRepository(
   default_branch: String,
   owner: ApiUser) {
   val forks_count   = forks
-  val watchers_coun = watchers
+  val watchers_count = watchers
   val url       = ApiPath(s"/api/v3/repos/${full_name}")
   val http_url  = ApiPath(s"/git/${full_name}.git")
   val clone_url = ApiPath(s"/git/${full_name}.git")

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -56,7 +56,7 @@ class JsonFormatSpec extends Specification {
     "default_branch" : "master",
     "owner" : $apiUserJson,
     "forks_count" : 0,
-    "watchers_coun" : 0,
+    "watchers_count" : 0,
     "url" : "${context.baseUrl}/api/v3/repos/octocat/Hello-World",
     "http_url" : "${context.baseUrl}/git/octocat/Hello-World.git",
     "clone_url" : "${context.baseUrl}/git/octocat/Hello-World.git",


### PR DESCRIPTION
The correct field in the JSON should be `watchers_count` rather than the truncated version `watchers_coun`.

This was spotted when I was testing the webhook-support against an internal service.