### PR TITLE
Specify option to generate an RSA host key

### DIFF
--- a/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
+++ b/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
@@ -14,7 +14,7 @@ object SshServer {
 
   private def configure(port: Int, baseUrl: String) = {
     server.setPort(port)
-    server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(s"${Directory.GitBucketHome}/gitbucket.ser"))
+    server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(s"${Directory.GitBucketHome}/gitbucket.ser", "RSA"))
     server.setPublickeyAuthenticator(new PublicKeyAuthenticator)
     server.setCommandFactory(new GitCommandFactory(baseUrl))
     server.setShellFactory(new NoShell)


### PR DESCRIPTION
As it is written on [the openssh-7.0 release note](http://www.openssh.com/txt/release-7.0
), ssh-dss support is disabled by default.
> * Support for ssh-dss, ssh-dss-cert-* host and user keys is disabled
>   by default at run-time. These may be re-enabled using the
>   instructions at http://www.openssh.com/legacy.html

But org.apache.sshd.common.keyprovider.AbstractKeyPairProvider which provides ssh access function uses dss host key by default and therefore we can not access to repositories via ssh in some environments.

SimpleGeneratorHostKeyProvider will generate a RSA host key when there is no existing host key, so we need to remove it manually.