### PR TITLE
Truncate long repository names in the repository list

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -295,6 +295,9 @@ div > div.box-content-row:nth-of-type(1) {
 div.box-content-row {
   border-top: 1px solid #d8d8d8;
   padding: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 div.box-content-bottom {


### PR DESCRIPTION
Truncate text inside a box-content-row div rather than flowing out of the box