### PR TITLE
Fix ArrayIndexOutOfBoundsException of IssuesService

### DIFF
--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -476,8 +476,11 @@ object IssuesService {
     def apply(filter: String, milestones: Map[String, Int]): IssueSearchCondition = {
       val conditions = filter.split("[ 　\t]+").map { x =>
         val dim = x.split(":")
-        dim(0) -> dim(1)
-      }.groupBy(_._1).map { case (key, values) =>
+        dim match {
+           case Array(_,_) => dim(0) -> dim(1)
+           case _ => "x" -> "x"
+        }
+      }.filter(_._1 != "x").groupBy(_._1).map { case (key, values) =>
         key -> values.map(_._2).toSeq
       }
 


### PR DESCRIPTION
Hi
I'm using Gitbucket 3.6.

I caught exception when trying to filter Issues like "is:open snowgooseyk".

I fixed this issue.

```
java.lang.ArrayIndexOutOfBoundsException: 1
	at gitbucket.core.service.IssuesService$IssueSearchCondition$$anonfun$19.apply(IssuesService.scala:479)
	at gitbucket.core.service.IssuesService$IssueSearchCondition$$anonfun$19.apply(IssuesService.scala:477)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:245)
	at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:186)
	at gitbucket.core.service.IssuesService$IssueSearchCondition$.apply(IssuesService.scala:477)
	at gitbucket.core.controller.DashboardControllerBase$$anonfun$1$$anonfun$apply$1$$anonfun$apply$2.apply(DashboardController.scala:21)
	at gitbucket.core.controller.DashboardControllerBase$$anonfun$1$$anonfun$apply$1$$anonfun$apply$2.apply(DashboardController.scala:20)
	at scala.Option.map(Option.scala:146)
	at gitbucket.core.controller.DashboardControllerBase$$anonfun$1$$anonfun$apply$1.apply(DashboardController.scala:20)
	at gitbucket.core.controller.DashboardControllerBase$$anonfun$1$$anonfun$apply$1.apply(DashboardController.scala:17)
	at gitbucket.core.util.UsersAuthenticator$class.gitbucket$core$util$UsersAuthenticator$$authenticate(Authenticator.scala:64)
	at gitbucket.core.util.UsersAuthenticator$class.usersOnly(Authenticator.scala:58)
	at gitbucket.core.controller.DashboardController.usersOnly(DashboardController.scala:9)
	at gitbucket.core.controller.DashboardControllerBase$$anonfun$1.apply(DashboardController.scala:17)
	at org.scalatra.ScalatraBase$class.org$scalatra$ScalatraBase$$liftAction(ScalatraBase.scala:270)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:265)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:265)
	at org.scalatra.ApiFormats$class.withRouteMultiParams(ApiFormats.scala:182)
	at gitbucket.core.controller.ControllerBase.withRouteMultiParams(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$class.invoke(ScalatraBase.scala:264)
	at gitbucket.core.controller.ControllerBase.org$scalatra$json$JsonSupport$$super$invoke(ControllerBase.scala:27)
	at org.scalatra.json.JsonSupport$$anonfun$invoke$1.apply(JsonSupport.scala:88)
	at org.scalatra.json.JsonSupport$$anonfun$invoke$1.apply(JsonSupport.scala:82)
	at org.scalatra.ApiFormats$class.withRouteMultiParams(ApiFormats.scala:182)
	at gitbucket.core.controller.ControllerBase.withRouteMultiParams(ControllerBase.scala:27)
	at org.scalatra.json.JsonSupport$class.invoke(JsonSupport.scala:82)
	at gitbucket.core.controller.ControllerBase.invoke(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:240)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:238)
	at scala.Option.flatMap(Option.scala:171)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:238)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:237)
	at scala.collection.immutable.Stream.flatMap(Stream.scala:493)
	at org.scalatra.ScalatraBase$class.runRoutes(ScalatraBase.scala:237)
	at gitbucket.core.controller.ControllerBase.runRoutes(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$class.runActions$1(ScalatraBase.scala:163)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply$mcV$sp(ScalatraBase.scala:175)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply(ScalatraBase.scala:175)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply(ScalatraBase.scala:175)
	at org.scalatra.ScalatraBase$class.org$scalatra$ScalatraBase$$cradleHalt(ScalatraBase.scala:193)
	at org.scalatra.ScalatraBase$class.executeRoutes(ScalatraBase.scala:175)
	at gitbucket.core.controller.ControllerBase.executeRoutes(ControllerBase.scala:27)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply$mcV$sp(ScalatraBase.scala:113)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply(ScalatraBase.scala:113)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply(ScalatraBase.scala:113)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
	at org.scalatra.DynamicScope$class.withResponse(DynamicScope.scala:80)
```