### PR TITLE
(ref #933) fix/Unable to download large file

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -298,7 +298,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
             contentType = "application/octet-stream"
             response.setContentLength(loader.getSize.toInt)
             loader.copyTo(response.getOutputStream)
-            Unit
+            ()
           } getOrElse NotFound
         } else {
           html.blob(id, repository, path.split("/").toList,

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -293,8 +293,12 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       getPathObjectId(git, path, revCommit).map { objectId =>
         if(raw){
           // Download
-          JGitUtil.getContentFromId(git, objectId, true).map { bytes =>
-            RawData("application/octet-stream", bytes)
+          JGitUtil.getObjectLoaderFromId(git, objectId){ loader =>
+            //RawData("application/octet-stream", bytes)
+            contentType = "application/octet-stream"
+            response.setContentLength(loader.getSize.toInt)
+            loader.copyTo(response.getOutputStream)
+            Unit
           } getOrElse NotFound
         } else {
           html.blob(id, repository, path.split("/").toList,

--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -731,7 +731,7 @@ object JGitUtil {
    * @param f the function process ObjectLoader
    * @return None if object does not exist
    */
-  def loaderFromId[A](git: Git, id: ObjectId)(f: ObjectLoader => A):Option[A] = try {
+  def getObjectLoaderFromId[A](git: Git, id: ObjectId)(f: ObjectLoader => A):Option[A] = try {
     using(git.getRepository.getObjectDatabase){ db =>
       Some(f(db.open(id)))
     }

--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -713,11 +713,27 @@ object JGitUtil {
   def getContentFromId(git: Git, id: ObjectId, fetchLargeFile: Boolean): Option[Array[Byte]] = try {
     using(git.getRepository.getObjectDatabase){ db =>
       val loader = db.open(id)
-      if(fetchLargeFile == false && FileUtil.isLarge(loader.getSize)){
+      if(loader.isLarge || (fetchLargeFile == false && FileUtil.isLarge(loader.getSize))){
         None
       } else {
         Some(loader.getBytes)
       }
+    }
+  } catch {
+    case e: MissingObjectException => None
+  }
+
+  /**
+   * Get objectLoader of the given object id from the Git repository.
+   *
+   * @param git the Git object
+   * @param id the object id
+   * @param f the function process ObjectLoader
+   * @return None if object does not exist
+   */
+  def loaderFromId[A](git: Git, id: ObjectId)(f: ObjectLoader => A):Option[A] = try {
+    using(git.getRepository.getObjectDatabase){ db =>
+      Some(f(db.open(id)))
     }
   } catch {
     case e: MissingObjectException => None


### PR DESCRIPTION
I think we should be avoided that an exception ( separate issue from that gitbucket managing a large file with git ).
The cause of this exception is that FileUtil.isLarge has not compatibility with ObjectLoader.isLarge.

and I Think that

 1. JGitUtil.getContentFromId(git: Git, id: ObjectId, fetchLargeFile: Boolean) to deprecated
 2. `getContentFromId` split to 2 methods. `getObjectLoaderFromId` for large binary, and `getContentTextFromId` for small text contents.

This patch added only `getObjectLoaderFromId`.